### PR TITLE
feature/force-download

### DIFF
--- a/src/addon.rs
+++ b/src/addon.rs
@@ -36,6 +36,7 @@ pub struct Addon {
     // States for GUI
     pub details_btn_state: iced::button::State,
     pub update_btn_state: iced::button::State,
+    pub force_btn_state: iced::button::State,
     pub delete_btn_state: iced::button::State,
 }
 
@@ -65,6 +66,7 @@ impl Addon {
             repository_identifiers,
             details_btn_state: Default::default(),
             update_btn_state: Default::default(),
+            force_btn_state: Default::default(),
             delete_btn_state: Default::default(),
         }
     }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -218,8 +218,8 @@ impl Application for Ajour {
             .width(Length::Units(85))
             .style(style::StatusTextContainer);
 
-        let delete_row_text = Text::new("Details").size(default_font_size);
-        let delete_row_container = Container::new(delete_row_text)
+        let details_row_text = Text::new("Details").size(default_font_size);
+        let details_row_container = Container::new(details_row_text)
             .width(Length::Units(70))
             .style(style::StatusTextContainer);
 
@@ -231,7 +231,7 @@ impl Application for Ajour {
                 .push(local_version_container)
                 .push(remote_version_container)
                 .push(status_row_container)
-                .push(delete_row_container)
+                .push(details_row_container)
                 .push(right_spacer);
         }
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -391,6 +391,23 @@ impl Application for Ajour {
                 let bottom_space = Space::new(Length::Units(0), Length::Units(4));
                 let notes_text = Text::new(notes).size(default_font_size);
 
+                let mut force_download_button = Button::new(
+                    &mut addon.force_btn_state,
+                    Text::new("Force update").size(default_font_size),
+                )
+                .style(style::DefaultBoxedButton);
+
+                // If we have remote version on addon, enable force update.
+                if addon.remote_version.is_some() {
+                    force_download_button =
+                        force_download_button.on_press(Interaction::Update(addon.id.clone()));
+                }
+
+                let force_download_button: Element<Interaction> = force_download_button.into();
+
+                // Space between buttons.
+                let button_space = Space::new(Length::Units(5), Length::Units(0));
+
                 let delete_button: Element<Interaction> = Button::new(
                     &mut addon.delete_btn_state,
                     Text::new("Delete").size(default_font_size),
@@ -399,12 +416,17 @@ impl Application for Ajour {
                 .style(style::DeleteBoxedButton)
                 .into();
 
-                let row = Row::new().push(delete_button.map(Message::Interaction));
+                let row = Row::new()
+                    .push(force_download_button.map(Message::Interaction))
+                    .push(button_space)
+                    .push(delete_button.map(Message::Interaction));
+
                 let column = Column::new()
                     .push(notes_text)
                     .push(space)
                     .push(row)
                     .push(bottom_space);
+
                 let details_container = Container::new(column)
                     .width(Length::Fill)
                     .padding(5)


### PR DESCRIPTION
When pressing details you can now force update an addon. This is only enabled if the addon has a `remote_version`.

Fixes #47.

<!-- START pr-commits -->
<!-- END pr-commits -->