### PR TITLE
use shared client for throttling per host

### DIFF
--- a/src/curse_api.rs
+++ b/src/curse_api.rs
@@ -32,10 +32,10 @@ pub struct Module {
 }
 
 /// Function to fetch a remote addon package for id.
-pub async fn fetch_remote_package(id: &u32) -> Result<Package> {
+pub async fn fetch_remote_package(shared_client: &HttpClient, id: &u32) -> Result<Package> {
     let url = format!("{}/{}", API_ENDPOINT, id);
     let timeout = Some(30);
-    let mut resp = request_async(&url, vec![], timeout).await?;
+    let mut resp = request_async(shared_client, &url, vec![], timeout).await?;
     if resp.status().is_success() {
         let package: Package = resp.json()?;
         Ok(package)
@@ -48,7 +48,10 @@ pub async fn fetch_remote_package(id: &u32) -> Result<Package> {
 }
 
 /// Function to fetch a remote addon packages for a search string.
-pub async fn fetch_remote_packages(search_string: &str) -> Result<Vec<Package>> {
+pub async fn fetch_remote_packages(
+    shared_client: &HttpClient,
+    search_string: &str,
+) -> Result<Vec<Package>> {
     let game_id = 1; // wow
     let page_size = 20; // capping results
     let timeout = Some(15);
@@ -58,7 +61,7 @@ pub async fn fetch_remote_packages(search_string: &str) -> Result<Vec<Package>> 
         API_ENDPOINT, game_id, page_size, search_string
     );
 
-    let mut resp = request_async(&url, vec![], timeout).await?;
+    let mut resp = request_async(shared_client, &url, vec![], timeout).await?;
     if resp.status().is_success() {
         let packages: Vec<Package> = resp.json()?;
         Ok(packages)

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -9,9 +9,14 @@ use crate::{
     error::ClientError,
     tukui_api, wowinterface_api, Result,
 };
+use async_std::sync::Arc;
 use iced::{
     button, pick_list, scrollable, Application, Column, Command, Container, Element, Length,
     Settings, Space,
+};
+use isahc::{
+    config::{Configurable, RedirectPolicy},
+    HttpClient,
 };
 use std::path::PathBuf;
 
@@ -64,6 +69,7 @@ pub struct Ajour {
     config: Config,
     expanded_addon: Option<Addon>,
     is_showing_settings: bool,
+    shared_client: Arc<HttpClient>,
 }
 
 impl Default for Ajour {
@@ -80,6 +86,13 @@ impl Default for Ajour {
             config: Config::default(),
             expanded_addon: None,
             is_showing_settings: false,
+            shared_client: Arc::new(
+                HttpClient::builder()
+                    .redirect_policy(RedirectPolicy::Follow)
+                    .max_connections_per_host(6)
+                    .build()
+                    .unwrap(),
+            ),
         }
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,11 +1,11 @@
 use crate::{addon::Addon, Result};
 use async_std::{fs::File, prelude::*};
-use isahc::config::RedirectPolicy;
 use isahc::prelude::*;
 use std::path::PathBuf;
 
 /// Generic request function.
 pub async fn request_async<T: ToString>(
+    shared_client: &HttpClient,
     url: T,
     headers: Vec<(&str, &str)>,
     timeout: Option<u64>,
@@ -14,24 +14,29 @@ pub async fn request_async<T: ToString>(
     // Sometimes a download url has a space.
     // FIXME: Can we do this more elegant?
     let url = url.to_string().replace(" ", "%20");
-    let mut client = HttpClient::builder().redirect_policy(RedirectPolicy::Follow);
+
+    let mut request = Request::builder().uri(url);
 
     for (name, value) in headers {
-        client = client.default_header(name, value);
+        request = request.header(name, value);
     }
 
     if let Some(timeout) = timeout {
-        client = client.timeout(std::time::Duration::from_secs(timeout));
+        request = request.timeout(std::time::Duration::from_secs(timeout));
     }
 
-    Ok(client.build()?.get_async(url.to_string()).await?)
+    Ok(shared_client.send_async(request.body(())?).await?)
 }
 
 /// Function to download a zip archive for a `Addon`.
 /// Note: Addon needs to have a `remote_url` to the file.
-pub async fn download_addon(addon: &Addon, to_directory: &PathBuf) -> Result<()> {
+pub async fn download_addon(
+    shared_client: &HttpClient,
+    addon: &Addon,
+    to_directory: &PathBuf,
+) -> Result<()> {
     let url = addon.remote_url.clone().unwrap();
-    let mut resp = request_async(url, vec![], None).await?;
+    let mut resp = request_async(shared_client, url, vec![], None).await?;
     let body = resp.body_mut();
     let zip_path = to_directory.join(&addon.id);
     let mut buffer = [0; 8000]; // 8KB

--- a/src/tukui_api.rs
+++ b/src/tukui_api.rs
@@ -21,10 +21,10 @@ fn api_endpoint(id: &str) -> String {
 
 /// Function to fetch a remote addon package which contains
 /// information about the addon on the repository.
-pub async fn fetch_remote_package(id: &str) -> Result<Package> {
+pub async fn fetch_remote_package(shared_client: &HttpClient, id: &str) -> Result<Package> {
     let url = api_endpoint(id);
     let timeout = Some(30);
-    let mut resp = request_async(&url, vec![], timeout).await?;
+    let mut resp = request_async(shared_client, &url, vec![], timeout).await?;
 
     if resp.status().is_success() {
         let package: Package = resp.json()?;

--- a/src/wowinterface_api.rs
+++ b/src/wowinterface_api.rs
@@ -15,11 +15,15 @@ pub struct Package {
 /// Function to fetch remote addon packages which contains
 /// information about the addon on the repository.
 /// Note: More packages can be returned for a single `Addon`
-pub async fn fetch_remote_packages(id: &str, token: &str) -> Result<Vec<Package>> {
+pub async fn fetch_remote_packages(
+    shared_client: &HttpClient,
+    id: &str,
+    token: &str,
+) -> Result<Vec<Package>> {
     let url = format!("{}/details/{}.json", API_ENDPOINT, id);
     let headers = vec![("x-api-token", token)];
     let timeout = Some(30);
-    let mut resp = request_async(url, headers, timeout).await?;
+    let mut resp = request_async(shared_client, url, headers, timeout).await?;
 
     if resp.status().is_success() {
         let addon_details: Vec<Package> = resp.json()?;


### PR DESCRIPTION
resolves #45 

Haven't tested this as I don't have any WoW installed / addons on my machine. It should limit 6 connections per API host by using a shared client across all requests and specifying `max_connections_per_host(6)`