### PR TITLE
make columns sortable

### DIFF
--- a/src/addon.rs
+++ b/src/addon.rs
@@ -2,13 +2,13 @@ use crate::{config::Flavor, curse_api, tukui_api, utility::strip_non_digits, wow
 use std::cmp::Ordering;
 use std::path::PathBuf;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub enum AddonState {
-    Ajour(Option<String>),
-    Loading,
     Updatable,
+    Loading,
     Downloading,
     Unpacking,
+    Ajour(Option<String>),
 }
 
 #[derive(Debug, Clone)]
@@ -239,22 +239,18 @@ impl PartialEq for Addon {
 impl PartialOrd for Addon {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(
-            self.is_updatable()
-                .cmp(&other.is_updatable())
-                .then_with(|| self.remote_version.cmp(&other.remote_version))
-                .reverse()
-                .then_with(|| self.title.cmp(&other.title)),
+            self.title
+                .cmp(&other.title)
+                .then_with(|| self.remote_version.cmp(&other.remote_version).reverse()),
         )
     }
 }
 
 impl Ord for Addon {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.is_updatable()
-            .cmp(&other.is_updatable())
-            .then_with(|| self.remote_version.cmp(&other.remote_version))
-            .reverse()
-            .then_with(|| self.title.cmp(&other.title))
+        self.title
+            .cmp(&other.title)
+            .then_with(|| self.remote_version.cmp(&other.remote_version).reverse())
     }
 }
 

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -1,5 +1,8 @@
 use {
-    super::{style, Addon, AddonState, AjourState, Config, Flavor, Interaction, Message},
+    super::{
+        style, Addon, AddonState, AjourState, Config, Flavor, Interaction, Message, SortKey,
+        SortState,
+    },
     crate::VERSION,
     iced::{
         button, pick_list, scrollable, Button, Column, Container, Element, HorizontalAlignment,
@@ -364,31 +367,55 @@ pub fn addon_data_cell(addon: &'_ mut Addon, is_addon_expanded: bool) -> Contain
         .style(style::Row)
 }
 
-pub fn addon_row_titles<'a>(addons: &[Addon]) -> Row<'a, Message> {
+pub fn addon_row_titles<'a>(addons: &[Addon], sort_state: &'a mut SortState) -> Row<'a, Message> {
     // A row containing titles above the addon rows.
-    let mut row_titles = Row::new().spacing(1).height(Length::Units(20));
+    let mut row_titles = Row::new().spacing(1).height(Length::Units(25));
 
     // We add some margin left to adjust for inner-marigin in cell.
     let left_spacer = Space::new(Length::Units(DEFAULT_PADDING + 5), Length::Units(0));
     let right_spacer = Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0));
 
-    let addon_row_text = Text::new("Addon").size(DEFAULT_FONT_SIZE);
-    let addon_row_container = Container::new(addon_row_text)
+    let addon_row_header: Element<Interaction> = Button::new(
+        &mut sort_state.title_btn_state,
+        Text::new("Addon").size(DEFAULT_FONT_SIZE),
+    )
+    .style(style::ColumnHeaderButton)
+    .on_press(Interaction::SortColumn(SortKey::Title))
+    .into();
+    let addon_row_container = Container::new(addon_row_header.map(Message::Interaction))
         .width(Length::FillPortion(1))
         .style(style::SecondaryTextContainer);
 
-    let local_version_text = Text::new("Local").size(DEFAULT_FONT_SIZE);
-    let local_version_container = Container::new(local_version_text)
+    let local_row_header: Element<Interaction> = Button::new(
+        &mut sort_state.local_version_btn_state,
+        Text::new("Local").size(DEFAULT_FONT_SIZE),
+    )
+    .style(style::ColumnHeaderButton)
+    .on_press(Interaction::SortColumn(SortKey::LocalVersion))
+    .into();
+    let local_version_container = Container::new(local_row_header.map(Message::Interaction))
         .width(Length::Units(150))
         .style(style::SecondaryTextContainer);
 
-    let remote_version_text = Text::new("Remote").size(DEFAULT_FONT_SIZE);
-    let remote_version_container = Container::new(remote_version_text)
+    let remote_row_header: Element<Interaction> = Button::new(
+        &mut sort_state.remote_version_btn_state,
+        Text::new("Remote").size(DEFAULT_FONT_SIZE),
+    )
+    .style(style::ColumnHeaderButton)
+    .on_press(Interaction::SortColumn(SortKey::RemoteVersion))
+    .into();
+    let remote_version_container = Container::new(remote_row_header.map(Message::Interaction))
         .width(Length::Units(150))
         .style(style::SecondaryTextContainer);
 
-    let status_row_text = Text::new("Status").size(DEFAULT_FONT_SIZE);
-    let status_row_container = Container::new(status_row_text)
+    let status_row_header: Element<Interaction> = Button::new(
+        &mut sort_state.status_btn_state,
+        Text::new("Status").size(DEFAULT_FONT_SIZE),
+    )
+    .style(style::ColumnHeaderButton)
+    .on_press(Interaction::SortColumn(SortKey::Status))
+    .into();
+    let status_row_container = Container::new(status_row_header.map(Message::Interaction))
         .width(Length::Units(85))
         .style(style::SecondaryTextContainer);
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -43,6 +43,7 @@ pub enum Interaction {
     Unignore(String),
     Update(String),
     UpdateAll,
+    SortColumn(SortKey),
 }
 
 #[derive(Debug)]
@@ -81,6 +82,7 @@ pub struct Ajour {
     shared_client: Arc<HttpClient>,
     state: AjourState,
     update_all_btn_state: button::State,
+    sort_state: SortState,
 }
 
 impl Default for Ajour {
@@ -109,6 +111,7 @@ impl Default for Ajour {
 
             state: AjourState::Idle,
             update_all_btn_state: Default::default(),
+            sort_state: Default::default(),
         }
     }
 }
@@ -159,7 +162,7 @@ impl Application for Ajour {
         // Addon row titles is a row of titles above the addon scrollable.
         // This is to add titles above each section of the addon row, to let
         // the user easily identify what the value is.
-        let addon_row_titles = element::addon_row_titles(&self.addons);
+        let addon_row_titles = element::addon_row_titles(&self.addons, &mut self.sort_state);
 
         // A scrollable list containing rows.
         // Each row holds data about a single addon.
@@ -243,4 +246,37 @@ pub fn run() {
 
     // Runs the GUI.
     Ajour::run(settings);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SortKey {
+    Title,
+    LocalVersion,
+    RemoteVersion,
+    Status,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SortDirection {
+    Asc,
+    Desc,
+}
+
+impl SortDirection {
+    fn toggle(self) -> SortDirection {
+        match self {
+            SortDirection::Asc => SortDirection::Desc,
+            SortDirection::Desc => SortDirection::Asc,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct SortState {
+    previous_sort_key: Option<SortKey>,
+    previous_sort_direction: Option<SortDirection>,
+    title_btn_state: button::State,
+    local_version_btn_state: button::State,
+    remote_version_btn_state: button::State,
+    status_btn_state: button::State,
 }

--- a/src/gui/style.rs
+++ b/src/gui/style.rs
@@ -158,6 +158,32 @@ impl button::StyleSheet for DeleteBoxedButton {
     }
 }
 
+pub struct ColumnHeaderButton;
+impl button::StyleSheet for ColumnHeaderButton {
+    fn active(&self) -> button::Style {
+        button::Style {
+            background: Some(Background::Color(ColorPalette::Background.rgb())),
+            text_color: Color {
+                a: 0.4,
+                ..ColorPalette::OnSurface.rgb()
+            },
+            border_radius: 2,
+            ..button::Style::default()
+        }
+    }
+
+    fn hovered(&self) -> button::Style {
+        button::Style {
+            background: Some(Background::Color(Color {
+                a: 0.1,
+                ..ColorPalette::Primary.rgb()
+            })),
+            text_color: ColorPalette::Primary.rgb(),
+            ..self.active()
+        }
+    }
+}
+
 pub struct Content;
 impl container::StyleSheet for Content {
     fn style(&self) -> container::Style {

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -610,30 +610,53 @@ async fn perform_unpack_addon(
 }
 
 fn sort_addons(addons: &mut [Addon], sort_direction: SortDirection, sort_key: SortKey) {
-    match sort_key {
-        SortKey::Title => {
+    match (sort_key, sort_direction) {
+        (SortKey::Title, SortDirection::Asc) => {
             addons.sort();
         }
-        SortKey::LocalVersion => {
+        (SortKey::Title, SortDirection::Desc) => {
+            addons.sort_by(|a, b| {
+                a.title
+                    .cmp(&b.title)
+                    .reverse()
+                    .then_with(|| a.remote_version.cmp(&b.remote_version))
+            });
+        }
+        (SortKey::LocalVersion, SortDirection::Asc) => {
             addons.sort_by(|a, b| {
                 a.version
                     .cmp(&b.version)
                     .then_with(|| a.title.cmp(&b.title))
             });
         }
-        SortKey::RemoteVersion => {
+        (SortKey::LocalVersion, SortDirection::Desc) => {
+            addons.sort_by(|a, b| {
+                a.version
+                    .cmp(&b.version)
+                    .reverse()
+                    .then_with(|| a.title.cmp(&b.title))
+            });
+        }
+        (SortKey::RemoteVersion, SortDirection::Asc) => {
             addons.sort_by(|a, b| {
                 a.remote_version
                     .cmp(&b.remote_version)
                     .then_with(|| a.cmp(&b))
             });
         }
-        SortKey::Status => {
+        (SortKey::RemoteVersion, SortDirection::Desc) => {
+            addons.sort_by(|a, b| {
+                a.remote_version
+                    .cmp(&b.remote_version)
+                    .reverse()
+                    .then_with(|| a.cmp(&b))
+            });
+        }
+        (SortKey::Status, SortDirection::Asc) => {
             addons.sort_by(|a, b| a.state.cmp(&b.state).then_with(|| a.cmp(&b)));
         }
-    }
-
-    if sort_direction == SortDirection::Desc {
-        addons.reverse();
+        (SortKey::Status, SortDirection::Desc) => {
+            addons.sort_by(|a, b| a.state.cmp(&b.state).reverse().then_with(|| a.cmp(&b)));
+        }
     }
 }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1,5 +1,5 @@
 use {
-    super::{Ajour, AjourState, Interaction, Message},
+    super::{Ajour, AjourState, Interaction, Message, SortDirection, SortKey},
     crate::{
         addon::{Addon, AddonState},
         config::{load_config, persist_config, Flavor},
@@ -267,7 +267,19 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
 
             // Once filtred, we set state.
             ajour.addons = addons;
-            ajour.addons.sort();
+
+            // Sort with state if sorting has been applied by user, otherwise use
+            // default sort.
+            if ajour.sort_state.previous_sort_key.is_some()
+                && ajour.sort_state.previous_sort_direction.is_some()
+            {
+                let sort_key = ajour.sort_state.previous_sort_key.unwrap();
+                let sort_direction = ajour.sort_state.previous_sort_direction.unwrap();
+
+                sort_addons(&mut ajour.addons, sort_direction, sort_key);
+            } else {
+                ajour.addons.sort();
+            }
 
             // Create a `Vec` of commands for fetching remote packages for each addon.
             let mut commands = Vec::<Command<Message>>::new();
@@ -412,6 +424,31 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
         }
         Message::NeedsUpdate(Ok(newer_version)) => {
             ajour.needs_update = newer_version;
+        }
+        Message::Interaction(Interaction::SortColumn(sort_key)) => {
+            // First time clicking a column should sort it in Ascending order, otherwise
+            // flip the sort direction.
+            let mut sort_direction = SortDirection::Asc;
+
+            if let Some(previous_sort_key) = ajour.sort_state.previous_sort_key {
+                if sort_key == previous_sort_key {
+                    if let Some(previous_sort_direction) = ajour.sort_state.previous_sort_direction
+                    {
+                        sort_direction = previous_sort_direction.toggle()
+                    }
+                }
+            }
+
+            // Exception would be first time ever sorting and sorting by title.
+            // Since its already sorting in Asc by default, we should sort Desc.
+            if ajour.sort_state.previous_sort_key.is_none() && sort_key == SortKey::Title {
+                sort_direction = SortDirection::Desc;
+            }
+
+            sort_addons(&mut ajour.addons, sort_direction, sort_key);
+
+            ajour.sort_state.previous_sort_direction = Some(sort_direction);
+            ajour.sort_state.previous_sort_key = Some(sort_key);
         }
         Message::Error(error)
         | Message::Parse(Err(error))
@@ -570,4 +607,33 @@ async fn perform_unpack_addon(
             .await
             .map(|_| ()),
     )
+}
+
+fn sort_addons(addons: &mut [Addon], sort_direction: SortDirection, sort_key: SortKey) {
+    match sort_key {
+        SortKey::Title => {
+            addons.sort();
+        }
+        SortKey::LocalVersion => {
+            addons.sort_by(|a, b| {
+                a.version
+                    .cmp(&b.version)
+                    .then_with(|| a.title.cmp(&b.title))
+            });
+        }
+        SortKey::RemoteVersion => {
+            addons.sort_by(|a, b| {
+                a.remote_version
+                    .cmp(&b.remote_version)
+                    .then_with(|| a.cmp(&b))
+            });
+        }
+        SortKey::Status => {
+            addons.sort_by(|a, b| a.state.cmp(&b.state).then_with(|| a.cmp(&b)));
+        }
+    }
+
+    if sort_direction == SortDirection::Desc {
+        addons.reverse();
+    }
 }


### PR DESCRIPTION
resolves #37 

Fix `Ord` and `PartialOrd` to sort properly. Updatable addons sort to top, then sort by title ascending. If title's match, then sort by remote version descending.

Sort addons after folder is initially parsed, each addon metadata is downloaded (to determine if updatabable or not) and after each package is updated (to resort by name).