### PR TITLE
check for newer version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "image",
  "isahc",
  "native-dialog",
+ "opener",
  "percent-encoding",
  "regex",
  "serde",
@@ -1880,6 +1881,15 @@ name = "once_cell"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+
+[[package]]
+name = "opener"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13117407ca9d0caf3a0e74f97b490a7e64c0ae3aa90a8b7085544d0c37b6f3ae"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "openssl-probe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ zip = "0.5.6"
 percent-encoding = "2.1.0"
 image = "0.23.8"
 native-dialog = "0.4.2"
+opener = "0.4.1"
 
 [build-dependencies]
 embed-resource = "1.3.3"

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -491,7 +491,7 @@ pub fn menu_container<'a>(
         .style(style::StatusErrorTextContainer);
 
     let version_text = Text::new(if let Some(new_version) = needs_update {
-        format!("New version available {} -> {}", VERSION, new_version)
+        format!("New Ajour version available {} -> {}", VERSION, new_version)
     } else {
         VERSION.to_owned()
     })
@@ -531,6 +531,7 @@ pub fn menu_container<'a>(
         .push(error_container)
         .push(version_container);
 
+    // Add download button to latest github release page if Ajour update is available.
     if needs_update.is_some() {
         let mut new_release_button = Button::new(
             new_release_button_state,

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -1,5 +1,6 @@
 use {
     super::{style, Addon, AddonState, AjourState, Config, Flavor, Interaction, Message},
+    crate::VERSION,
     iced::{
         button, pick_list, scrollable, Button, Column, Container, Element, HorizontalAlignment,
         Length, PickList, Row, Scrollable, Space, Text, VerticalAlignment,
@@ -425,6 +426,7 @@ pub fn menu_container<'a>(
     state: &AjourState,
     addons: &[Addon],
     config: &Config,
+    needs_update: Option<&'a str>,
 ) -> Container<'a, Message> {
     // A row contain general settings.
     let mut settings_row = Row::new().spacing(1).height(Length::Units(35));
@@ -486,13 +488,20 @@ pub fn menu_container<'a>(
         .width(Length::FillPortion(1))
         .style(style::StatusErrorTextContainer);
 
-    let version_text = Text::new(env!("CARGO_PKG_VERSION"))
-        .size(DEFAULT_FONT_SIZE)
-        .horizontal_alignment(HorizontalAlignment::Right);
-    let version_container = Container::new(version_text)
-        .center_y()
-        .padding(5)
-        .style(style::SecondaryTextContainer);
+    let version_text = Text::new(if let Some(new_version) = needs_update {
+        format!("New version available {} -> {}", VERSION, new_version)
+    } else {
+        VERSION.to_owned()
+    })
+    .size(DEFAULT_FONT_SIZE)
+    .horizontal_alignment(HorizontalAlignment::Right);
+
+    let mut version_container = Container::new(version_text).center_y().padding(5);
+    if needs_update.is_some() {
+        version_container = version_container.style(style::StatusErrorTextContainer);
+    } else {
+        version_container = version_container.style(style::SecondaryTextContainer);
+    }
 
     let settings_button: Element<Interaction> = Button::new(
         settings_button_state,

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -419,6 +419,7 @@ pub fn addon_row_titles<'a>(addons: &[Addon]) -> Row<'a, Message> {
     row_titles
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn menu_container<'a>(
     update_all_button_state: &'a mut button::State,
     refresh_button_state: &'a mut button::State,
@@ -427,6 +428,7 @@ pub fn menu_container<'a>(
     addons: &[Addon],
     config: &Config,
     needs_update: Option<&'a str>,
+    new_release_button_state: &'a mut button::State,
 ) -> Container<'a, Message> {
     // A row contain general settings.
     let mut settings_row = Row::new().spacing(1).height(Length::Units(35));
@@ -527,7 +529,28 @@ pub fn menu_container<'a>(
         .push(refresh_button.map(Message::Interaction))
         .push(status_container)
         .push(error_container)
-        .push(version_container)
+        .push(version_container);
+
+    if needs_update.is_some() {
+        let mut new_release_button = Button::new(
+            new_release_button_state,
+            Text::new("Download").size(DEFAULT_FONT_SIZE),
+        )
+        .style(style::SecondaryButton);
+
+        new_release_button = new_release_button.on_press(Interaction::OpenLink(
+            "https://github.com/casperstorm/ajour/releases/latest".to_owned(),
+        ));
+
+        let new_release_button: Element<Interaction> = new_release_button.into();
+
+        let spacer = Space::new(Length::Units(3), Length::Units(0));
+
+        settings_row = settings_row.push(new_release_button.map(Message::Interaction));
+        settings_row = settings_row.push(spacer);
+    }
+
+    settings_row = settings_row
         .push(settings_button.map(Message::Interaction))
         .push(right_spacer);
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -61,6 +61,7 @@ pub enum Message {
     UpdateDirectory(Option<PathBuf>),
     FlavorSelected(Flavor),
     NeedsUpdate(Result<Option<String>>),
+    None(()),
 }
 
 pub struct Ajour {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -42,6 +42,7 @@ pub enum Interaction {
     Expand(String),
     Ignore(String),
     Unignore(String),
+    OpenLink(String),
 }
 
 #[derive(Debug)]
@@ -78,6 +79,7 @@ pub struct Ajour {
     is_showing_settings: bool,
     shared_client: Arc<HttpClient>,
     needs_update: Option<String>,
+    new_release_button_state: button::State,
 }
 
 impl Default for Ajour {
@@ -104,6 +106,7 @@ impl Default for Ajour {
                     .unwrap(),
             ),
             needs_update: None,
+            new_release_button_state: Default::default(),
         }
     }
 }
@@ -148,6 +151,7 @@ impl Application for Ajour {
             &self.addons,
             &self.config,
             self.needs_update.as_deref(),
+            &mut self.new_release_button_state,
         );
 
         // Addon row titles is a row of titles above the addon scrollable.

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -401,10 +401,14 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 }
             }
         }
+        Message::NeedsUpdate(Ok(newer_version)) => {
+            ajour.needs_update = newer_version;
+        }
         Message::Error(error)
         | Message::Parse(Err(error))
         | Message::ParsedAddons(Err(error))
-        | Message::PartialParsedAddons(Err(error)) => {
+        | Message::PartialParsedAddons(Err(error))
+        | Message::NeedsUpdate(Err(error)) => {
             ajour.state = AjourState::Error(error);
         }
     }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -94,6 +94,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
         Message::Interaction(Interaction::OpenDirectory) => {
             return Ok(Command::perform(open_directory(), Message::UpdateDirectory));
         }
+        Message::Interaction(Interaction::OpenLink(link)) => {
+            let _ = opener::open(link);
+        }
         Message::UpdateDirectory(path) => {
             if path.is_some() {
                 // Update the path for World of Warcraft.

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -95,7 +95,12 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             return Ok(Command::perform(open_directory(), Message::UpdateDirectory));
         }
         Message::Interaction(Interaction::OpenLink(link)) => {
-            let _ = opener::open(link);
+            return Ok(Command::perform(
+                async {
+                    let _ = opener::open(link);
+                },
+                Message::None,
+            ));
         }
         Message::UpdateDirectory(path) => {
             if path.is_some() {
@@ -414,6 +419,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
         | Message::NeedsUpdate(Err(error)) => {
             ajour.state = AjourState::Error(error);
         }
+        Message::None(_) => {}
     }
 
     Ok(Command::none())

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ mod wowinterface_api;
 
 use crate::error::ClientError;
 
-pub const VERSION: &str = "0.2.1"; //env!("CARGO_PKG_VERSION");
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub type Result<T> = std::result::Result<T, ClientError>;
 pub fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ mod wowinterface_api;
 
 use crate::error::ClientError;
 
+pub const VERSION: &str = "0.2.1"; //env!("CARGO_PKG_VERSION");
+
 pub type Result<T> = std::result::Result<T, ClientError>;
 pub fn main() {
     // Start the GUI

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -1,4 +1,7 @@
+use crate::{network::request_async, Result, VERSION};
+use isahc::prelude::*;
 use regex::Regex;
+use serde::Deserialize;
 
 /// Takes a `&str` and strips any non-digit.
 /// This is used to unify and compare addon versions:
@@ -9,4 +12,26 @@ pub fn strip_non_digits(string: &str) -> Option<String> {
     let re = Regex::new(r"[\D]").unwrap();
     let stripped = re.replace_all(string, "").to_string();
     Some(stripped)
+}
+
+#[derive(Deserialize)]
+struct Release {
+    tag_name: String,
+}
+
+pub async fn needs_update() -> Result<Option<String>> {
+    let mut resp = request_async(
+        "https://api.github.com/repos/casperstorm/ajour/releases/latest",
+        vec![],
+        None,
+    )
+    .await?;
+
+    let release: Release = resp.json()?;
+
+    if release.tag_name != VERSION {
+        Ok(Some(release.tag_name))
+    } else {
+        Ok(None)
+    }
 }

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -20,7 +20,10 @@ struct Release {
 }
 
 pub async fn needs_update() -> Result<Option<String>> {
+    let client = HttpClient::new()?;
+
     let mut resp = request_async(
+        &client,
         "https://api.github.com/repos/casperstorm/ajour/releases/latest",
         vec![],
         None,


### PR DESCRIPTION
resolves #57 

I couldn't find a hyperlink widget in `Iced` for the user to click to take them to the latest release page. For now it just replaces the version with update text styled as an error.