### PR TITLE
synchronize updates to FingerprintCollection

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -6,11 +6,12 @@ use crate::{
     addon::{Addon, AddonState},
     config::{load_config, Config, Flavor},
     error::ClientError,
+    parse::FingerprintCollection,
     theme::{load_user_themes, ColorPalette, Theme},
     utility::needs_update,
     Result,
 };
-use async_std::sync::Arc;
+use async_std::sync::{Arc, Mutex};
 use iced::{
     button, pick_list, scrollable, Application, Column, Command, Container, Element, Length,
     Settings, Space,
@@ -83,6 +84,7 @@ pub struct Ajour {
     update_all_btn_state: button::State,
     sort_state: SortState,
     theme_state: ThemeState,
+    fingerprint_collection: Arc<Mutex<Option<FingerprintCollection>>>,
 }
 
 impl Default for Ajour {
@@ -112,6 +114,7 @@ impl Default for Ajour {
             update_all_btn_state: Default::default(),
             sort_state: Default::default(),
             theme_state: Default::default(),
+            fingerprint_collection: Arc::new(Mutex::new(None)),
         }
     }
 }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -35,7 +35,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
 
             if let Some(dir) = addon_directory {
                 return Ok(Command::perform(
-                    read_addon_directory(dir, flavor),
+                    read_addon_directory(ajour.fingerprint_collection.clone(), dir, flavor),
                     Message::ParsedAddons,
                 ));
             } else {
@@ -239,7 +239,10 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                         addon.state = AddonState::Ajour(Some("Completed".to_owned()));
                         addon.version = addon.remote_version.clone();
                         return Ok(Command::perform(
-                            update_addon_fingerprint(addon.clone()),
+                            update_addon_fingerprint(
+                                ajour.fingerprint_collection.clone(),
+                                addon.clone(),
+                            ),
                             Message::UpdateFingerprint,
                         ));
                     }


### PR DESCRIPTION
store FingerprintCollection in memory and only allow one operation on it at a time, so concurrent tasks can't overwrite changes to the collection. We still write changes to disk after each operation makes it's updates.