### PR TITLE
parse non-fingerprint curse-id matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` and `Removed`.
 
 ## [Unreleased]
+### Fixed
+- Include curse addons that failed fingerprinting
+  - Even though fingerprinting failed, there is still a curse project id that can be used to lookup the addon via the curse API. Previously these addons were not shown, but now they are included.
+
 ## [0.3.2] - 2020-09-11
 ### Changed
 - Light theme is now a bit more gentle to the eyes. Don't worry, it's still not default.
 - Switched Refresh and Update All buttons.
+
 ## [0.3.1] - 2020-09-11
 ### Fixed
 - Correctly rehashes addon after an update.

--- a/src/curse_api.rs
+++ b/src/curse_api.rs
@@ -14,6 +14,7 @@ const API_ENDPOINT: &str = "https://addons-ecs.forgesvc.net/api/v2";
 pub struct Package {
     pub id: u32,
     pub name: String,
+    pub latest_files: Vec<File>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -281,12 +281,27 @@ pub async fn read_addon_directory<P: AsRef<Path>>(
         })
         .collect();
 
+    // Addons that failed fingerprinting but can be looked up on Curse ID
+    let mut curse_id_only_addons: Vec<_> = unfiltred_addons
+        .iter()
+        .filter(|a| {
+            !fingerprint_addons.iter().any(|f| f.id == a.id)
+                && a.tukui_id.is_none()
+                && a.curse_id.is_some()
+        })
+        .cloned()
+        .collect();
+
     // Creates a `Vec` of curse_ids.
-    let curse_ids: Vec<_> = fingerprint_addons
+    let curse_ids: Vec<_> = unfiltred_addons
         .iter()
         .filter_map(|addon| {
             if let Some(curse_id) = addon.curse_id {
-                Some(curse_id)
+                if addon.tukui_id.is_none() {
+                    Some(curse_id)
+                } else {
+                    None
+                }
             } else {
                 None
             }
@@ -296,19 +311,34 @@ pub async fn read_addon_directory<P: AsRef<Path>>(
     // Fetches the curse packages based on the ids.
     let curse_id_packages_result = fetch_remote_packages_by_ids(&curse_ids).await;
     if let Ok(curse_id_packages) = curse_id_packages_result {
-        // Loops the packages, and updates our Addons with information.
-        for package in curse_id_packages {
+        // Loops the packages, and updates fingerprinted addons with package info
+        for package in curse_id_packages.iter() {
             let addon = fingerprint_addons
                 .iter_mut()
                 .find(|a| a.curse_id == Some(package.id));
             if let Some(addon) = addon {
-                addon.apply_curse_package(&package);
+                addon.apply_curse_package(&package, flavor, true);
+            }
+        }
+
+        // Loops the packages, and updates non-fingerprinted addons with package info
+        for package in curse_id_packages.iter() {
+            let addon = curse_id_only_addons
+                .iter_mut()
+                .find(|a| a.curse_id == Some(package.id));
+            if let Some(addon) = addon {
+                addon.apply_curse_package(&package, flavor, false);
             }
         }
     }
 
     // Concats the different repo addons, and returns.
-    let concatenated = [&fingerprint_addons[..], &tukui_addons[..]].concat();
+    let concatenated = [
+        &fingerprint_addons[..],
+        &tukui_addons[..],
+        &curse_id_only_addons[..],
+    ]
+    .concat();
     Ok(concatenated)
 }
 


### PR DESCRIPTION
partially addresses #90. We still don't show addons with no API hit.

All addons with a curse id can be queried against curse. Previously, only addons with exact fingerprints got curse package updates. This PR identifies the gap of addons that have a Curse ID, no Tukui ID, and were not successfully fingerprinted. We then apply the curse package.