### PR TITLE
check for case insensitive addons folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 ### Fixed
 - Include curse addons that failed fingerprinting
   - Even though fingerprinting failed, there is still a curse project id that can be used to lookup the addon via the curse API. Previously these addons were not shown, but now they are included.
+- Check for case-insensitive version of `Interface/AddOns` folder for robustness
 
 ## [0.3.2] - 2020-09-11
 ### Changed


### PR DESCRIPTION
resolves #96 

The `glob` crate is a little weird. I couldn't get it to match `interface/addons` even with the case insensitive option enabled. I was able to get it working by adding an actual pattern symbol within each component of the path patten, such as `?nterface/?ddons`. With this pattern, I have it working completely case insensitive. I've tested it with a bunch of combinations, including `InTeRFAcE/aDdONs`