### PR TITLE
feat: able to easily select flavor from menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` and `Removed`.
 
 ## [Unreleased]
+### Changed
+- Made it easier to use Ajour if you play both Classic and Retail by moving the control from settings into the menubar.
+  - Ajour will now parse both Classic and Retail directories on launch. This means that when you switch between the two it will now be instantaneously.
 ### Fixed
-
 - Better toc file parsing
   - We now have better logic catching the values inside the toc file
   - If we for some reason does not find a title for the addon, we fallback and use the foldername

--- a/src/addon.rs
+++ b/src/addon.rs
@@ -152,8 +152,11 @@ impl Addon {
     }
 
     /// Function returns a `bool` indicating if the user has manually ignored the addon.
-    pub fn is_ignored(&self, ignored: &[String]) -> bool {
-        ignored.iter().any(|i| i == &self.id)
+    pub fn is_ignored(&self, ignored: Option<&Vec<String>>) -> bool {
+        match ignored {
+            Some(ignored) => ignored.iter().any(|i| i == &self.id),
+            _ => false,
+        }
     }
 
     /// Check if the `Addon` is updatable.

--- a/src/config/addons.rs
+++ b/src/config/addons.rs
@@ -1,15 +1,19 @@
+use super::Flavor;
 use serde_derive::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Struct for addons specific settings.
 #[serde(default)]
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct Addons {
     #[serde(default)]
-    pub ignored: Vec<String>,
+    pub ignored: HashMap<Flavor, Vec<String>>,
 }
 
 impl Default for Addons {
     fn default() -> Self {
-        Addons { ignored: vec![] }
+        Addons {
+            ignored: HashMap::new(),
+        }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -26,12 +26,12 @@ pub struct Config {
 impl Config {
     /// Returns a `Option<PathBuf>` to the directory containing the addons.
     /// This will return `None` if no `wow_directory` is set in the config.
-    pub fn get_addon_directory(&self) -> Option<PathBuf> {
+    pub fn get_addon_directory_for_flavor(&self, flavor: &Flavor) -> Option<PathBuf> {
         match &self.wow.directory {
             Some(dir) => {
                 // We prepend and append `_` to the formatted_client_flavor so it
                 // either becomes _retail_, or _classic_.
-                let formatted_client_flavor = format!("_{}_", self.wow.flavor);
+                let formatted_client_flavor = format!("_{}_", flavor);
 
                 // The path to the directory containing the addons
                 let mut addon_dir = dir.join(&formatted_client_flavor).join("Interface/AddOns");
@@ -69,7 +69,8 @@ impl Config {
     /// For now it will use the parent of the Addons folder.
     /// This will return `None` if no `wow_directory` is set in the config.
     pub fn get_temporary_addon_directory(&self) -> Option<PathBuf> {
-        match self.get_addon_directory() {
+        let flavor = self.wow.flavor;
+        match self.get_addon_directory_for_flavor(&flavor) {
             Some(dir) => {
                 // The path to the directory which hold the temporary zip archives
                 let dir = dir.parent().expect("Expected Addons folder has a parent.");

--- a/src/config/wow.rs
+++ b/src/config/wow.rs
@@ -21,7 +21,7 @@ impl Default for Wow {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Hash)]
 pub enum Flavor {
     #[serde(alias = "retail")]
     Retail,

--- a/src/fs/save.rs
+++ b/src/fs/save.rs
@@ -43,17 +43,8 @@ pub trait PersistentData: DeserializeOwned + Serialize {
         let load_result = <T as PersistentData>::load();
 
         match load_result {
-            Err(ClientError::LoadFileDoesntExist(_)) => Ok(get_default_and_save()?),
-            Err(ClientError::YamlError(error)) => {
-                // Prevent parsing error with an empty string and commented out file.
-                if error.to_string() == "EOF while parsing a value" {
-                    Ok(get_default_and_save()?)
-                } else {
-                    Err(ClientError::YamlError(error))
-                }
-            }
-            Err(error) => Err(error),
             Ok(deser) => Ok(deser),
+            _ => Ok(get_default_and_save()?),
         }
     }
 

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -462,7 +462,7 @@ pub fn menu_container<'a>(
     classic_btn_state: &'a mut button::State,
     state: &AjourState,
     addons: &[Addon],
-    config: &Config,
+    config: &'a mut Config,
     needs_update: Option<&'a str>,
     new_release_button_state: &'a mut button::State,
 ) -> Container<'a, Message> {
@@ -544,10 +544,11 @@ pub fn menu_container<'a>(
         .push(classic_button.map(Message::Interaction));
 
     // Displays text depending on the state of the app.
-    let ignored_addons = config.addons.ignored.as_ref();
+    let flavor = config.wow.flavor;
+    let ignored_addons = config.addons.ignored.get(&flavor);
     let parent_addons_count = addons
         .iter()
-        .filter(|a| !a.is_ignored(&ignored_addons))
+        .filter(|a| !a.is_ignored(ignored_addons))
         .count();
 
     let status_text = match state {

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -173,7 +173,7 @@ pub fn settings_container<'a>(
         .push(right_spacer);
 
     // Returns the final container.
-    Container::new(row).height(Length::Units(150))
+    Container::new(row).height(Length::Units(130))
 }
 
 pub fn addon_data_cell(
@@ -487,6 +487,7 @@ pub fn menu_container<'a>(
         .any(|a| matches!(a.state, AddonState::Downloading | AddonState::Unpacking));
 
     let ajour_performing_actions = matches!(state, AjourState::Loading);
+    let ajour_welcome = matches!(state, AjourState::Welcome);
 
     // Is any addon updtable.
     let any_addon_updatable = addons
@@ -523,7 +524,7 @@ pub fn menu_container<'a>(
     )
     .style(style::SegmentedButton(color_palette));
 
-    if !ajour_performing_actions {
+    if !ajour_performing_actions && !ajour_welcome {
         match config.wow.flavor {
             Flavor::Retail => {
                 classic_button =

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -5,8 +5,8 @@ use {
     },
     crate::VERSION,
     iced::{
-        button, pick_list, scrollable, Button, Column, Container, Element, HorizontalAlignment,
-        Length, PickList, Row, Scrollable, Space, Text, VerticalAlignment,
+        button, scrollable, Button, Column, Container, Element, HorizontalAlignment, Length,
+        PickList, Row, Scrollable, Space, Text, VerticalAlignment,
     },
 };
 
@@ -18,7 +18,6 @@ static DEFAULT_PADDING: u16 = 10;
 pub fn settings_container<'a>(
     color_palette: ColorPalette,
     directory_button_state: &'a mut button::State,
-    flavor_list_state: &'a mut pick_list::State<Flavor>,
     ignored_addons_scrollable_state: &'a mut scrollable::State,
     ignored_addons: &'a mut Vec<(Addon, button::State)>,
     config: &Config,
@@ -64,27 +63,6 @@ pub fn settings_container<'a>(
         .push(directory_button.map(Message::Interaction))
         .push(directory_data_text_container);
 
-    // Title for the flavor pick list.
-    let flavor_info_text = Text::new("Flavor").size(14);
-    let flavor_info_row = Row::new().push(flavor_info_text).padding(DEFAULT_PADDING);
-
-    // We add some margin left to adjust to the rest of the content.
-    let left_spacer = Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0));
-
-    let flavors = &Flavor::ALL[..];
-    let flavor_pick_list = PickList::new(
-        flavor_list_state,
-        flavors,
-        Some(config.wow.flavor),
-        Message::FlavorSelected,
-    )
-    .text_size(14)
-    .width(Length::Units(100))
-    .style(style::PickList(color_palette));
-
-    // Data row for flavor picker list.
-    let flavor_data_row = Row::new().push(left_spacer).push(flavor_pick_list);
-
     // Title for the theme pick list.
     let theme_info_text = Text::new("Theme").size(14);
     let theme_info_row = Row::new().push(theme_info_text).padding(DEFAULT_PADDING);
@@ -118,8 +96,6 @@ pub fn settings_container<'a>(
     let left_column = Column::new()
         .push(directory_info_row)
         .push(path_data_row)
-        .push(flavor_info_row)
-        .push(flavor_data_row)
         .push(theme_info_row)
         .push(theme_data_row)
         .push(bottom_space);
@@ -197,7 +173,7 @@ pub fn settings_container<'a>(
         .push(right_spacer);
 
     // Returns the final container.
-    Container::new(row).height(Length::Units(185))
+    Container::new(row).height(Length::Units(150))
 }
 
 pub fn addon_data_cell(
@@ -482,6 +458,8 @@ pub fn menu_container<'a>(
     update_all_button_state: &'a mut button::State,
     refresh_button_state: &'a mut button::State,
     settings_button_state: &'a mut button::State,
+    retail_btn_state: &'a mut button::State,
+    classic_btn_state: &'a mut button::State,
     state: &AjourState,
     addons: &[Addon],
     config: &Config,
@@ -489,7 +467,7 @@ pub fn menu_container<'a>(
     new_release_button_state: &'a mut button::State,
 ) -> Container<'a, Message> {
     // A row contain general settings.
-    let mut settings_row = Row::new().spacing(1).height(Length::Units(35));
+    let mut settings_row = Row::new().height(Length::Units(35));
 
     let mut update_all_button = Button::new(
         update_all_button_state,
@@ -533,6 +511,37 @@ pub fn menu_container<'a>(
     let update_all_button: Element<Interaction> = update_all_button.into();
     let refresh_button: Element<Interaction> = refresh_button.into();
 
+    let mut retail_button = Button::new(
+        retail_btn_state,
+        Text::new("Retail").size(DEFAULT_FONT_SIZE),
+    )
+    .style(style::SegmentedButton(color_palette));
+
+    let mut classic_button = Button::new(
+        classic_btn_state,
+        Text::new("Classic").size(DEFAULT_FONT_SIZE),
+    )
+    .style(style::SegmentedButton(color_palette));
+
+    if !ajour_performing_actions {
+        match config.wow.flavor {
+            Flavor::Retail => {
+                classic_button =
+                    classic_button.on_press(Interaction::FlavorSelected(Flavor::Classic));
+            }
+            Flavor::Classic => {
+                retail_button = retail_button.on_press(Interaction::FlavorSelected(Flavor::Retail));
+            }
+        }
+    }
+
+    let retail_button: Element<Interaction> = retail_button.into();
+    let classic_button: Element<Interaction> = classic_button.into();
+
+    let segmented_flavor_control_container = Row::new()
+        .push(retail_button.map(Message::Interaction))
+        .push(classic_button.map(Message::Interaction));
+
     // Displays text depending on the state of the app.
     let ignored_addons = config.addons.ignored.as_ref();
     let parent_addons_count = addons
@@ -541,9 +550,12 @@ pub fn menu_container<'a>(
         .count();
 
     let status_text = match state {
-        AjourState::Idle => {
-            Text::new(format!("{} addons loaded", parent_addons_count)).size(DEFAULT_FONT_SIZE)
-        }
+        AjourState::Idle => Text::new(format!(
+            "{} {} addons loaded",
+            parent_addons_count,
+            config.wow.flavor.to_string()
+        ))
+        .size(DEFAULT_FONT_SIZE),
         _ => Text::new(""),
     };
 
@@ -592,7 +604,6 @@ pub fn menu_container<'a>(
     .on_press(Interaction::Settings)
     .into();
 
-    let spacer = Space::new(Length::Units(7), Length::Units(0));
     // Not using default padding, just to make it look prettier UI wise
     let top_spacer = Space::new(Length::Units(0), Length::Units(5));
     let left_spacer = Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0));
@@ -602,8 +613,10 @@ pub fn menu_container<'a>(
     settings_row = settings_row
         .push(left_spacer)
         .push(refresh_button.map(Message::Interaction))
-        .push(spacer)
+        .push(Space::new(Length::Units(7), Length::Units(0)))
         .push(update_all_button.map(Message::Interaction))
+        .push(Space::new(Length::Units(7), Length::Units(0)))
+        .push(segmented_flavor_control_container)
         .push(status_container)
         .push(error_container)
         .push(version_container);

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -20,6 +20,7 @@ use isahc::{
     config::{Configurable, RedirectPolicy},
     HttpClient,
 };
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use image::ImageFormat;
@@ -46,6 +47,7 @@ pub enum Interaction {
     Update(String),
     UpdateAll,
     SortColumn(SortKey),
+    FlavorSelected(Flavor),
 }
 
 #[derive(Debug)]
@@ -53,12 +55,11 @@ pub enum Message {
     ConfigDirExists(PathBuf),
     DownloadedAddon((String, Result<()>)),
     Error(ClientError),
-    FlavorSelected(Flavor),
     Interaction(Interaction),
     NeedsUpdate(Result<Option<String>>),
     None(()),
     Parse(Result<Config>),
-    ParsedAddons(Result<Vec<Addon>>),
+    ParsedAddons(Result<(Flavor, Vec<Addon>)>),
     UpdateFingerprint((String, Result<()>)),
     ThemeSelected(String),
     ThemesLoaded(Vec<Theme>),
@@ -67,12 +68,11 @@ pub enum Message {
 }
 
 pub struct Ajour {
-    addons: Vec<Addon>,
+    addons: HashMap<Flavor, Vec<Addon>>,
     addons_scrollable_state: scrollable::State,
     config: Config,
     directory_btn_state: button::State,
     expanded_addon: Option<Addon>,
-    flavor_list_state: pick_list::State<Flavor>,
     ignored_addons: Vec<(Addon, button::State)>,
     ignored_addons_scrollable_state: scrollable::State,
     is_showing_settings: bool,
@@ -86,18 +86,19 @@ pub struct Ajour {
     sort_state: SortState,
     theme_state: ThemeState,
     fingerprint_collection: Arc<Mutex<Option<FingerprintCollection>>>,
+    retail_btn_state: button::State,
+    classic_btn_state: button::State,
 }
 
 impl Default for Ajour {
     fn default() -> Self {
         Self {
-            addons: Vec::new(),
+            addons: HashMap::new(),
             addons_scrollable_state: Default::default(),
             config: Config::default(),
             directory_btn_state: Default::default(),
             expanded_addon: None,
-            flavor_list_state: Default::default(),
-            ignored_addons: Vec::new(),
+            ignored_addons: Default::default(),
             ignored_addons_scrollable_state: Default::default(),
             is_showing_settings: false,
             needs_update: None,
@@ -116,6 +117,8 @@ impl Default for Ajour {
             sort_state: Default::default(),
             theme_state: Default::default(),
             fingerprint_collection: Arc::new(Mutex::new(None)),
+            retail_btn_state: Default::default(),
+            classic_btn_state: Default::default(),
         }
     }
 }
@@ -146,12 +149,6 @@ impl Application for Ajour {
     }
 
     fn view(&mut self) -> Element<Message> {
-        let has_addons = !&self.addons.is_empty();
-
-        // Ignored addons.
-        // We find the  corresponding `Addon` from the ignored strings.
-        let ignored_strings = &self.config.addons.ignored;
-
         // Get color palette of chosen theme.
         let color_palette = self
             .theme_state
@@ -163,15 +160,28 @@ impl Application for Ajour {
             .1
             .palette;
 
+        // Get addons for current flavor.
+        let flavor = self.config.wow.flavor.clone();
+        let addons = self.addons.entry(flavor).or_insert(Vec::new());
+
+        // Check if we have any addons.
+        let has_addons = !&addons.is_empty();
+
+        // Ignored addons.
+        // We find the  corresponding `Addon` from the ignored strings.
+        let ignored_strings = &self.config.addons.ignored;
+
         // Menu container at the top of the applications.
         // This has all global buttons, such as Settings, Update All, etc.
         let menu_container = element::menu_container(
             color_palette,
             &mut self.update_all_btn_state,
             &mut self.refresh_btn_state,
+            &mut self.retail_btn_state,
+            &mut self.classic_btn_state,
             &mut self.settings_btn_state,
             &self.state,
-            &self.addons,
+            addons,
             &self.config,
             self.needs_update.as_deref(),
             &mut self.new_release_button_state,
@@ -181,7 +191,7 @@ impl Application for Ajour {
         // This is to add titles above each section of the addon row, to let
         // the user easily identify what the value is.
         let addon_row_titles =
-            element::addon_row_titles(color_palette, &self.addons, &mut self.sort_state);
+            element::addon_row_titles(color_palette, addons, &mut self.sort_state);
 
         // A scrollable list containing rows.
         // Each row holds data about a single addon.
@@ -189,8 +199,7 @@ impl Application for Ajour {
             element::addon_scrollable(color_palette, &mut self.addons_scrollable_state);
 
         // Loops though the addons.
-        for addon in &mut self
-            .addons
+        for addon in &mut addons
             .iter_mut()
             .filter(|a| !a.is_ignored(&ignored_strings))
         {
@@ -220,7 +229,6 @@ impl Application for Ajour {
             let settings_container = element::settings_container(
                 color_palette,
                 &mut self.directory_btn_state,
-                &mut self.flavor_list_state,
                 &mut self.ignored_addons_scrollable_state,
                 &mut self.ignored_addons,
                 &self.config,

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -262,7 +262,7 @@ impl Application for Ajour {
                     Some(element::status_container(
                         color_palette,
                         "Woops!",
-                        "It seems you have no addons in your AddOn directory.",
+                        &format!("You have no {} addons.", flavor.to_string().to_lowercase()),
                     ))
                 } else {
                     None

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -59,7 +59,7 @@ pub enum Message {
     NeedsUpdate(Result<Option<String>>),
     None(()),
     Parse(Result<Config>),
-    ParsedAddons(Result<(Flavor, Vec<Addon>)>),
+    ParsedAddons((Flavor, Result<Vec<Addon>>)),
     UpdateFingerprint((String, Result<()>)),
     ThemeSelected(String),
     ThemesLoaded(Vec<Theme>),

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -161,8 +161,8 @@ impl Application for Ajour {
             .palette;
 
         // Get addons for current flavor.
-        let flavor = self.config.wow.flavor.clone();
-        let addons = self.addons.entry(flavor).or_insert(Vec::new());
+        let flavor = self.config.wow.flavor;
+        let addons = self.addons.entry(flavor).or_insert_with(Vec::new);
 
         // Check if we have any addons.
         let has_addons = !&addons.is_empty();

--- a/src/gui/style.rs
+++ b/src/gui/style.rs
@@ -163,6 +163,46 @@ impl button::StyleSheet for ColumnHeaderButton {
     }
 }
 
+pub struct SegmentedButton(pub ColorPalette);
+impl button::StyleSheet for SegmentedButton {
+    fn active(&self) -> button::Style {
+        button::Style {
+            background: Some(Background::Color(Color {
+                a: 0.03,
+                ..self.0.primary
+            })),
+            text_color: self.0.primary,
+            border_radius: 2,
+            ..button::Style::default()
+        }
+    }
+
+    fn hovered(&self) -> button::Style {
+        button::Style {
+            background: Some(Background::Color(Color {
+                a: 0.1,
+                ..self.0.primary
+            })),
+            text_color: self.0.primary,
+            ..self.active()
+        }
+    }
+
+    fn disabled(&self) -> button::Style {
+        button::Style {
+            background: Some(Background::Color(Color {
+                a: 0.01,
+                ..self.0.primary
+            })),
+            text_color: Color {
+                a: 0.1,
+                ..self.0.primary
+            },
+            ..self.active()
+        }
+    }
+}
+
 pub struct Content(pub ColorPalette);
 impl container::StyleSheet for Content {
     fn style(&self) -> container::Style {

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -177,17 +177,17 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                     .config
                     .get_addon_directory_for_flavor(&flavor)
                     .expect("has to have addon directory");
+
+                // Remove from local state.
+                let addons = ajour.addons.get_mut(flavor).expect("no addons for flavor");
+                addons.retain(|a| a.id != addon.id);
+
                 // Foldernames to the addons which is to be deleted.
                 let mut addons_to_be_deleted = [&addon.dependencies[..], &[addon.id]].concat();
-
-                // Ensure we don't have more of the same string.
                 addons_to_be_deleted.dedup();
-                let _ = delete_addons(&addon_directory, &addons_to_be_deleted);
-                // TODO: Does this work still?
-                let addons = ajour.addons.get_mut(flavor).expect("no addons for flavor");
-                // addons.retain(|ma| &addon.id != ma.id);
 
-                // mut_addons.retain(|a| !addons_to_be_deleted.iter().any(|ab| ab == &a.id));
+                // Delete addon(s) from disk.
+                let _ = delete_addons(&addon_directory, &addons_to_be_deleted);
             }
         }
         Message::Interaction(Interaction::Update(id)) => {

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -177,11 +177,17 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                     .config
                     .get_addon_directory_for_flavor(&flavor)
                     .expect("has to have addon directory");
-                let addons_to_be_deleted = [&addon.dependencies[..], &[addon.id]].concat();
+                // Foldernames to the addons which is to be deleted.
+                let mut addons_to_be_deleted = [&addon.dependencies[..], &[addon.id]].concat();
+
+                // Ensure we don't have more of the same string.
+                addons_to_be_deleted.dedup();
                 let _ = delete_addons(&addon_directory, &addons_to_be_deleted);
                 // TODO: Does this work still?
-                let mut_addons = ajour.addons.get_mut(flavor).expect("no addons for flavor");
-                mut_addons.retain(|a| !addons_to_be_deleted.iter().any(|ab| ab != &a.id));
+                let addons = ajour.addons.get_mut(flavor).expect("no addons for flavor");
+                // addons.retain(|ma| &addon.id != ma.id);
+
+                // mut_addons.retain(|a| !addons_to_be_deleted.iter().any(|ab| ab == &a.id));
             }
         }
         Message::Interaction(Interaction::Update(id)) => {

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -211,13 +211,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
             return Ok(Command::batch(commands));
         }
-        // Message::ParsedAddons(Ok((flavor, mut addons))) => {
         Message::ParsedAddons((flavor, result)) => {
-            // If our selected flavor returns error, we assume we have no valid addons.
-            let selected_flavor = ajour.config.wow.flavor;
-            // let is_empty = ajour.addons.get(flavor).map_or(false, |v| v.is_empty());
-
-            if flavor == selected_flavor {
+            // if our selected flavor returns (either ok or error) - we change to idle.
+            if flavor == ajour.config.wow.flavor {
                 ajour.state = AjourState::Idle;
             }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -148,7 +148,7 @@ pub async fn read_addon_directory<P: AsRef<Path>>(
                 .iter()
                 .find(|f| &f.flavor == flavor && &f.title == dir_name)
             {
-                fingerprint.to_owned().clone()
+                fingerprint.to_owned()
             } else {
                 let hash = fingerprint_addon_dir(
                     &addon_dir,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -104,7 +104,7 @@ pub async fn read_addon_directory<P: AsRef<Path>>(
     fingerprint_collection: Arc<Mutex<Option<FingerprintCollection>>>,
     root_dir: P,
     flavor: Flavor,
-) -> Result<(Flavor, Vec<Addon>)> {
+) -> Result<Vec<Addon>> {
     let root_dir = root_dir.as_ref();
 
     // If the path does not exists or does not point on a directory we return an Error.
@@ -317,7 +317,7 @@ pub async fn read_addon_directory<P: AsRef<Path>>(
 
     // Concats the different repo addons, and returns.
     let concatenated = [&fingerprint_addons[..], &tukui_addons[..]].concat();
-    Ok((flavor, concatenated))
+    Ok(concatenated)
 }
 
 pub async fn update_addon_fingerprint(


### PR DESCRIPTION
This PR makes it easier to switch between flavors (retail/classic). The dropdown menu is moved to the menu row, and both directories are parsed, if there's any addons to parse.

It's a rather big refactor for a small feature, but that's because we are moving away from keeping addons in a `Vec<Addon>` but instead having them in a `HashMap` where `flavor` is key, and `Vec<Addon>` is value. This requires a little bit of plumping here and there.

Feel free to codereview as I go along, @tarkah - it's still a bit messy but you might already have comments.