### PR TITLE
add local logging for debugging

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,3 +31,6 @@ Please complete the following information:
 
 **Additional context**
 Add any other context about the problem here.
+
+**Log Output**
+Paste the content of `ajour.log` from `%APPDATA%\ajour\ajour.log` on Windows or `$HOME/.config/ajour/ajour.log` on Mac/Linux.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 ### Added
 - Improve clarity of row titles to reflect current sort state
   - A little up-, or down-arrow has been added to indicate sort direction, and a color has been added to the selected colum.
+- Added local logging for debugging the application. An `ajour.log` file is saved in the ajour config directory. This file can be shared along with any bug reports to help better debug the issue.
 ### Changed
 - Made it easier to use Ajour if you play both Classic and Retail by moving the control from settings into the menubar.
   - Ajour will now parse both Classic and Retail directories on launch. This means that when you switch between the two it will now be instantaneously.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,15 +42,18 @@ name = "ajour"
 version = "0.3.3"
 dependencies = [
  "async-std",
+ "chrono",
  "dirs 3.0.1",
  "embed-resource",
  "fancy-regex",
+ "fern",
  "glob",
  "iced",
  "iced_futures",
  "image",
  "isahc",
  "lazy_static",
+ "log",
  "native-dialog",
  "opener",
  "percent-encoding",
@@ -309,6 +312,17 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "chrono"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942f72db697d8767c22d46a598e01f2d3b475501ea43d0db4f16d90259182d0b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "time",
+]
 
 [[package]]
 name = "clipboard-win"
@@ -773,6 +787,15 @@ name = "fastrand"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36a9cb09840f81cd211e435d00a4e487edd263dc3c8ff815c32dd76ad668ebed"
+
+[[package]]
+name = "fern"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9a4820f0ccc8a7afd67c39a0f1a0f4b07ca1725164271a64939d7aeb9af065"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "flate2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ opener = "0.4.1"
 glob = "0.3.0"
 rayon = "1.4.0"
 lazy_static = "1.4.0"
+chrono = "0.4"
+log = "0.4"
+fern = "0.6"
 
 [build-dependencies]
 embed-resource = "1.3.3"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -91,5 +91,7 @@ impl PersistentData for Config {
 ///
 /// This functions handles the initialization of a Config.
 pub async fn load_config() -> Result<Config> {
+    log::debug!("loading config");
+
     Ok(Config::load_or_default()?)
 }

--- a/src/curse_api.rs
+++ b/src/curse_api.rs
@@ -80,7 +80,7 @@ pub struct FingerprintInfo {
     pub is_cache_built: bool,
     pub exact_matches: Vec<AddonFingerprintInfo>,
     pub exact_fingerprints: Vec<u32>,
-    pub partial_matches: Vec<::serde_json::Value>,
+    pub partial_matches: Vec<AddonFingerprintInfo>,
     pub partial_match_fingerprints: ::serde_json::Value,
     pub installed_fingerprints: Vec<u32>,
     pub unmatched_fingerprints: Vec<u32>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,13 @@ pub enum ClientError {
     ZipError(zip::result::ZipError),
     LoadFileDoesntExist(PathBuf),
     LogError(String),
+    FingerprintError(String),
+}
+
+impl ClientError {
+    pub fn fingerprint(e: impl fmt::Display) -> ClientError {
+        ClientError::FingerprintError(format!("{}", e))
+    }
 }
 
 impl fmt::Display for ClientError {
@@ -28,6 +35,7 @@ impl fmt::Display for ClientError {
             Self::ZipError(x) => write!(f, "{}", x),
             Self::LoadFileDoesntExist(x) => write!(f, "file doesn't exist: {:?}", x),
             Self::LogError(x) => write!(f, "{}", x),
+            Self::FingerprintError(x) => write!(f, "{}", x),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ pub enum ClientError {
     NetworkError(isahc::Error),
     ZipError(zip::result::ZipError),
     LoadFileDoesntExist(PathBuf),
+    LogError(String),
 }
 
 impl fmt::Display for ClientError {
@@ -26,6 +27,7 @@ impl fmt::Display for ClientError {
             Self::HttpError(x) => write!(f, "{}", x),
             Self::ZipError(x) => write!(f, "{}", x),
             Self::LoadFileDoesntExist(x) => write!(f, "file doesn't exist: {:?}", x),
+            Self::LogError(x) => write!(f, "{}", x),
         }
     }
 }
@@ -63,5 +65,17 @@ impl From<isahc::http::Error> for ClientError {
 impl From<zip::result::ZipError> for ClientError {
     fn from(error: zip::result::ZipError) -> Self {
         Self::ZipError(error)
+    }
+}
+
+impl From<fern::InitError> for ClientError {
+    fn from(error: fern::InitError) -> Self {
+        Self::LogError(format!("{:?}", error))
+    }
+}
+
+impl From<log::SetLoggerError> for ClientError {
+    fn from(error: log::SetLoggerError) -> Self {
+        Self::LogError(format!("{:?}", error))
     }
 }

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -22,6 +22,7 @@ pub fn config_dir() -> PathBuf {
 
     if !config_dir.exists() {
         fs::create_dir(&config_dir).expect("could not create folder $HOME/.config/ajour");
+        log::debug!("config directory created");
     }
 
     config_dir
@@ -39,6 +40,7 @@ pub fn config_dir() -> PathBuf {
 
     if !config_dir.exists() {
         fs::create_dir(&config_dir).expect("could not create folder %APPDATA%\\ajour");
+        log::debug!("config directory created");
     }
 
     config_dir

--- a/src/fs/theme.rs
+++ b/src/fs/theme.rs
@@ -34,5 +34,7 @@ pub async fn load_user_themes() -> Vec<Theme> {
         }
     }
 
+    log::debug!("loaded {} user themes", themes.len());
+
     themes
 }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -31,6 +31,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
         }
         Message::Parse(Ok(config)) => {
             log::debug!("Message::Parse");
+            log::debug!("config loaded:\n{:#?}", config);
 
             // When we have the config, we parse the addon directory
             // which is provided by the config.
@@ -45,6 +46,11 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             let flavors = &Flavor::ALL[..];
             for flavor in flavors {
                 if let Some(addon_directory) = ajour.config.get_addon_directory_for_flavor(flavor) {
+                    log::debug!(
+                        "preparing to parse addons in {:?}",
+                        addon_directory.display()
+                    );
+
                     commands.push(Command::perform(
                         perform_read_addon_directory(
                             ajour.fingerprint_collection.clone(),
@@ -54,6 +60,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                         Message::ParsedAddons,
                     ));
                 } else {
+                    log::debug!("addon directory is not set, showing welcome screen");
+
                     // Assume we are welcoming a user because directory is not set.
                     ajour.state = AjourState::Welcome;
                     break;

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -30,6 +30,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             return Ok(Command::batch(commands));
         }
         Message::Parse(Ok(config)) => {
+            log::debug!("Message::Parse");
+
             // When we have the config, we parse the addon directory
             // which is provided by the config.
             ajour.config = config;
@@ -60,6 +62,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             return Ok(Command::batch(commands));
         }
         Message::Interaction(Interaction::Refresh) => {
+            log::debug!("Interaction::Refresh");
+
             // Close settings if shown.
             ajour.is_showing_settings = false;
 
@@ -72,9 +76,13 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             return Ok(Command::perform(load_config(), Message::Parse));
         }
         Message::Interaction(Interaction::Settings) => {
+            log::debug!("Interaction::Settings");
+
             ajour.is_showing_settings = !ajour.is_showing_settings;
         }
         Message::Interaction(Interaction::Ignore(id)) => {
+            log::debug!("Interaction::Ignore({})", &id);
+
             // Close settings if shown.
             ajour.is_showing_settings = false;
 
@@ -105,6 +113,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
         }
         Message::Interaction(Interaction::Unignore(id)) => {
+            log::debug!("Interaction::Unignore({})", &id);
+
             // Update ajour state.
             let flavor = ajour.config.wow.flavor;
             let ignored_addons = ajour.ignored_addons.entry(flavor).or_default();
@@ -118,9 +128,13 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             let _ = &ajour.config.save();
         }
         Message::Interaction(Interaction::OpenDirectory) => {
+            log::debug!("Interaction::OpenDirectory");
+
             return Ok(Command::perform(open_directory(), Message::UpdateDirectory));
         }
         Message::Interaction(Interaction::OpenLink(link)) => {
+            log::debug!("Interaction::OpenLink({})", &link);
+
             return Ok(Command::perform(
                 async {
                     let _ = opener::open(link);
@@ -129,6 +143,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             ));
         }
         Message::UpdateDirectory(path) => {
+            log::debug!("Message::UpdateDirectory({:?})", &path);
+
             // Clear addons.
             ajour.addons = HashMap::new();
 
@@ -144,6 +160,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
         }
         Message::Interaction(Interaction::FlavorSelected(flavor)) => {
+            log::debug!("Interaction::FlavorSelected({})", flavor);
+
             // Close settings if shown.
             ajour.is_showing_settings = false;
             // Update the game flavor
@@ -152,6 +170,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             let _ = &ajour.config.save();
         }
         Message::Interaction(Interaction::Expand(id)) => {
+            log::debug!("Interaction::Expand({})", &id);
+
             // Close settings if shown.
             ajour.is_showing_settings = false;
             // Expand a addon. If it's already expanded, we collapse it again.
@@ -171,6 +191,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
         }
         Message::Interaction(Interaction::Delete(id)) => {
+            log::debug!("Interaction::Delete({})", &id);
+
             // Close settings if shown.
             ajour.is_showing_settings = false;
 
@@ -195,6 +217,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
         }
         Message::Interaction(Interaction::Update(id)) => {
+            log::debug!("Interaction::Update({})", &id);
+
             // Close settings if shown.
             ajour.is_showing_settings = false;
 
@@ -219,6 +243,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
         }
         Message::Interaction(Interaction::UpdateAll) => {
+            log::debug!("Interaction::UpdateAll");
+
             // Close settings if shown.
             ajour.is_showing_settings = false;
 
@@ -251,6 +277,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
 
             if let Ok(mut addons) = result {
+                log::debug!("Message::ParsedAddons({}, {} addons)", flavor, addons.len(),);
+
                 // Sort the addons.
                 sort_addons(&mut addons, SortDirection::Desc, SortKey::Status);
                 ajour.sort_state.previous_sort_direction = Some(SortDirection::Desc);
@@ -273,9 +301,21 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
 
                 // Insert the addons into the HashMap.
                 ajour.addons.insert(flavor, addons);
+            } else {
+                log::error!(
+                    "Message::ParsedAddons({}) - {}",
+                    flavor,
+                    result.err().unwrap(),
+                );
             }
         }
         Message::DownloadedAddon((id, result)) => {
+            log::debug!(
+                "Message::DownloadedAddon(({}, error: {}))",
+                &id,
+                result.is_err()
+            );
+
             // When an addon has been successfully downloaded we begin to unpack it.
             // If it for some reason fails to download, we handle the error.
             let from_directory = ajour
@@ -307,6 +347,12 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
         }
         Message::UnpackedAddon((id, result)) => {
+            log::debug!(
+                "Message::UnpackedAddon(({}, error: {}))",
+                &id,
+                result.is_err()
+            );
+
             let flavor = ajour.config.wow.flavor;
             let addons = ajour.addons.entry(flavor).or_default();
             if let Some(addon) = addons.iter_mut().find(|a| a.id == id) {
@@ -356,6 +402,12 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
         }
         Message::UpdateFingerprint((id, result)) => {
+            log::debug!(
+                "Message::UpdateFingerprint(({}, error: {}))",
+                &id,
+                result.is_err()
+            );
+
             let flavor = ajour.config.wow.flavor;
             let addons = ajour.addons.entry(flavor).or_default();
             if let Some(addon) = addons.iter_mut().find(|a| a.id == id) {
@@ -367,6 +419,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
         }
         Message::NeedsUpdate(Ok(newer_version)) => {
+            log::debug!("Message::NeedsUpdate({:?})", &newer_version);
+
             ajour.needs_update = newer_version;
         }
         Message::Interaction(Interaction::SortColumn(sort_key)) => {
@@ -392,6 +446,12 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 sort_direction = SortDirection::Desc;
             }
 
+            log::debug!(
+                "Interaction::SortColumn({:?}, {:?})",
+                sort_key,
+                sort_direction
+            );
+
             let flavor = ajour.config.wow.flavor;
             let mut addons = ajour.addons.entry(flavor).or_default();
 
@@ -401,12 +461,16 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             ajour.sort_state.previous_sort_key = Some(sort_key);
         }
         Message::ThemeSelected(theme_name) => {
+            log::debug!("Message::ThemeSelected({:?})", &theme_name);
+
             ajour.theme_state.current_theme_name = theme_name.clone();
 
             ajour.config.theme = Some(theme_name);
             let _ = ajour.config.save();
         }
         Message::ThemesLoaded(mut themes) => {
+            log::debug!("Message::ThemesLoaded({} themes)", themes.len());
+
             themes.sort();
 
             for theme in themes {
@@ -414,6 +478,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
         }
         Message::Error(error) | Message::Parse(Err(error)) | Message::NeedsUpdate(Err(error)) => {
+            log::error!("{}", error);
+
             ajour.state = AjourState::Error(error);
         }
         Message::None(_) => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,51 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub type Result<T> = std::result::Result<T, ClientError>;
 pub fn main() {
+    // Setup the logger
+    setup_logger().expect("setup logging");
+
+    log::debug!("Ajour has started.");
+
     // Start the GUI
     gui::run();
+}
+
+#[allow(clippy::unnecessary_operation)]
+fn setup_logger() -> Result<()> {
+    let mut logger = fern::Dispatch::new()
+        .format(|out, message, record| {
+            out.finish(format_args!(
+                "{} [{}][{}] {}",
+                chrono::Local::now().format("%H:%M:%S%.3f"),
+                record.target(),
+                record.level(),
+                message
+            ))
+        })
+        .level(log::LevelFilter::Off)
+        .level_for("ajour", log::LevelFilter::Debug);
+
+    #[cfg(debug_assertions)]
+    {
+        logger = logger.chain(std::io::stdout());
+    };
+
+    #[cfg(not(debug_assertions))]
+    {
+        use std::fs::OpenOptions;
+
+        let config_dir = fs::config_dir();
+
+        let log_file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .append(false)
+            .truncate(true)
+            .open(config_dir.join("ajour.log"))?;
+
+        logger = logger.chain(log_file);
+    };
+
+    logger.apply()?;
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ pub fn main() {
     // Setup the logger
     setup_logger().expect("setup logging");
 
-    log::debug!("Ajour has started.");
+    log::debug!("Ajour {} has started.", VERSION);
 
     // Start the GUI
     gui::run();
@@ -44,7 +44,7 @@ fn setup_logger() -> Result<()> {
             ))
         })
         .level(log::LevelFilter::Off)
-        .level_for("ajour", log::LevelFilter::Debug);
+        .level_for("ajour", log::LevelFilter::Trace);
 
     #[cfg(debug_assertions)]
     {

--- a/src/network.rs
+++ b/src/network.rs
@@ -60,6 +60,12 @@ pub async fn download_addon(
     addon: &Addon,
     to_directory: &PathBuf,
 ) -> Result<()> {
+    log::debug!(
+        "downloading remote version {} for {}",
+        addon.remote_version.as_deref().unwrap_or_default(),
+        &addon.id
+    );
+
     if let Some(url) = addon.remote_url.clone() {
         let mut resp = request_async(shared_client, url, vec![], None).await?;
         let body = resp.body_mut();

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -583,7 +583,7 @@ fn fingerprint_addon_dir(
         // Parse file for matches
         let (comment_strip_regex, inclusion_regex) =
             file_parsing_regex.get(&ext).ok_or_else(|| {
-                ClientError::FingerprintError(format!("ext no in file parsing regex: {:?}", ext))
+                ClientError::FingerprintError(format!("ext not in file parsing regex: {:?}", ext))
             })?;
         let text = std::fs::read_to_string(&path).map_err(ClientError::fingerprint)?;
         let text = comment_strip_regex.replace_all(&text, "");

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -4,6 +4,8 @@ use serde::Deserialize;
 use std::cmp::Ordering;
 
 pub async fn load_user_themes() -> Vec<Theme> {
+    log::debug!("loading user themes");
+
     fs::load_user_themes().await
 }
 

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -20,6 +20,8 @@ struct Release {
 }
 
 pub async fn needs_update() -> Result<Option<String>> {
+    log::debug!("checking for application update");
+
     let client = HttpClient::new()?;
 
     let mut resp = request_async(


### PR DESCRIPTION
First commit is the meat of adding logging support for Ajour. On startup, it will create / truncate the log file so it should never grow too big and is only relevant to the last launch of the app.

- If `cargo run` it will log to console.

- If `cargo run --release` / binary is used, it will log to `$config/ajour/ajour.log`.

The rest is just going to be scattering `debug!` everywhere! I figured we can roll this out with everything as `DEBUG` and if needed, convert some stuff to `INFO` or `TRACE` as needed if there is too much noise.