### PR TITLE
feat: improve clarity of row titles to reflect current sort state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` and `Removed`.
 
 ## [Unreleased]
+### Added
+-  Improve clarity of row titles to reflect current sort state
+  - A little up-, or down-arrow has been added to indicate sort direction, and a color has been added to the selected colum.
 ### Fixed
-
 - Better toc file parsing
   - We now have better logic catching the values inside the toc file
   - If we for some reason does not find a title for the addon, we fallback and use the foldername

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -1,7 +1,7 @@
 use {
     super::{
         style, Addon, AddonState, AjourState, ColorPalette, Config, Flavor, Interaction, Message,
-        SortKey, SortState, ThemeState,
+        SortDirection, SortKey, SortState, ThemeState,
     },
     crate::VERSION,
     iced::{
@@ -369,6 +369,23 @@ pub fn addon_data_cell(
         .style(style::Row(color_palette))
 }
 
+fn row_title(
+    sort_key: SortKey,
+    previous_sort_key: Option<SortKey>,
+    previous_sort_direction: Option<SortDirection>,
+    title: &str,
+) -> String {
+    if Some(sort_key) == previous_sort_key {
+        match previous_sort_direction {
+            Some(SortDirection::Asc) => format!("{} ▲", title),
+            Some(SortDirection::Desc) => format!("{} ▼", title),
+            _ => title.to_string(),
+        }
+    } else {
+        title.to_string()
+    }
+}
+
 pub fn addon_row_titles<'a>(
     color_palette: ColorPalette,
     addons: &[Addon],
@@ -377,63 +394,120 @@ pub fn addon_row_titles<'a>(
     // A row containing titles above the addon rows.
     let mut row_titles = Row::new().spacing(1).height(Length::Units(25));
 
+    let addon_row_title = row_title(
+        SortKey::Title,
+        sort_state.previous_sort_key,
+        sort_state.previous_sort_direction,
+        "Addon",
+    );
+
+    let local_row_title = row_title(
+        SortKey::LocalVersion,
+        sort_state.previous_sort_key,
+        sort_state.previous_sort_direction,
+        "Local",
+    );
+
+    let remote_row_title = row_title(
+        SortKey::RemoteVersion,
+        sort_state.previous_sort_key,
+        sort_state.previous_sort_direction,
+        "Remote",
+    );
+
+    let status_row_title = row_title(
+        SortKey::Status,
+        sort_state.previous_sort_key,
+        sort_state.previous_sort_direction,
+        "Status",
+    );
+
     // We add some margin left to adjust for inner-marigin in cell.
     let left_spacer = Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0));
     let right_spacer = Space::new(Length::Units(DEFAULT_PADDING + 5), Length::Units(0));
 
-    let addon_row_header: Element<Interaction> = Button::new(
+    let mut addon_row_header = Button::new(
         &mut sort_state.title_btn_state,
-        Text::new("Addon")
+        Text::new(addon_row_title)
             .size(DEFAULT_FONT_SIZE)
             .width(Length::Fill),
     )
     .width(Length::Fill)
-    .style(style::ColumnHeaderButton(color_palette))
-    .on_press(Interaction::SortColumn(SortKey::Title))
-    .into();
+    .on_press(Interaction::SortColumn(SortKey::Title));
+
+    if sort_state.previous_sort_key == Some(SortKey::Title) {
+        addon_row_header = addon_row_header.style(style::SelectedColumnHeaderButton(color_palette));
+    } else {
+        addon_row_header = addon_row_header.style(style::ColumnHeaderButton(color_palette));
+    }
+
+    let addon_row_header: Element<Interaction> = addon_row_header.into();
 
     let addon_row_container = Container::new(addon_row_header.map(Message::Interaction))
         .width(Length::FillPortion(1))
         .style(style::SecondaryTextContainer(color_palette));
 
-    let local_row_header: Element<Interaction> = Button::new(
+    let mut local_row_header = Button::new(
         &mut sort_state.local_version_btn_state,
-        Text::new("Local")
+        Text::new(local_row_title)
             .size(DEFAULT_FONT_SIZE)
             .width(Length::Fill),
     )
     .width(Length::Fill)
-    .style(style::ColumnHeaderButton(color_palette))
-    .on_press(Interaction::SortColumn(SortKey::LocalVersion))
-    .into();
+    .on_press(Interaction::SortColumn(SortKey::LocalVersion));
+
+    if sort_state.previous_sort_key == Some(SortKey::LocalVersion) {
+        local_row_header = local_row_header.style(style::SelectedColumnHeaderButton(color_palette));
+    } else {
+        local_row_header = local_row_header.style(style::ColumnHeaderButton(color_palette));
+    }
+
+    let local_row_header: Element<Interaction> = local_row_header.into();
+
     let local_version_container = Container::new(local_row_header.map(Message::Interaction))
         .width(Length::Units(150))
         .style(style::SecondaryTextContainer(color_palette));
 
-    let remote_row_header: Element<Interaction> = Button::new(
+    let mut remote_row_header = Button::new(
         &mut sort_state.remote_version_btn_state,
-        Text::new("Remote")
+        Text::new(remote_row_title)
             .size(DEFAULT_FONT_SIZE)
             .width(Length::Fill),
     )
     .width(Length::Fill)
-    .style(style::ColumnHeaderButton(color_palette))
-    .on_press(Interaction::SortColumn(SortKey::RemoteVersion))
-    .into();
+    .on_press(Interaction::SortColumn(SortKey::RemoteVersion));
+
+    if sort_state.previous_sort_key == Some(SortKey::RemoteVersion) {
+        remote_row_header =
+            remote_row_header.style(style::SelectedColumnHeaderButton(color_palette));
+    } else {
+        remote_row_header = remote_row_header.style(style::ColumnHeaderButton(color_palette));
+    }
+
+    let remote_row_header: Element<Interaction> = remote_row_header.into();
+
     let remote_version_container = Container::new(remote_row_header.map(Message::Interaction))
         .width(Length::Units(150))
         .style(style::SecondaryTextContainer(color_palette));
 
-    let status_row_header: Element<Interaction> = Button::new(
+    let mut status_row_header = Button::new(
         &mut sort_state.status_btn_state,
-        Text::new("Status")
+        Text::new(status_row_title)
             .size(DEFAULT_FONT_SIZE)
             .width(Length::Fill),
     )
     .width(Length::Fill)
-    .style(style::ColumnHeaderButton(color_palette))
-    .on_press(Interaction::SortColumn(SortKey::Status))
-    .into();
+    .on_press(Interaction::SortColumn(SortKey::Status));
+
+    if sort_state.previous_sort_key == Some(SortKey::Status) {
+        status_row_header =
+            status_row_header.style(style::SelectedColumnHeaderButton(color_palette));
+    } else {
+        status_row_header = status_row_header.style(style::ColumnHeaderButton(color_palette));
+    }
+
+    let status_row_header: Element<Interaction> = status_row_header.into();
+
     let status_row_container = Container::new(status_row_header.map(Message::Interaction))
         .width(Length::Units(85))
         .style(style::SecondaryTextContainer(color_palette));

--- a/src/gui/style.rs
+++ b/src/gui/style.rs
@@ -163,6 +163,29 @@ impl button::StyleSheet for ColumnHeaderButton {
     }
 }
 
+pub struct SelectedColumnHeaderButton(pub ColorPalette);
+impl button::StyleSheet for SelectedColumnHeaderButton {
+    fn active(&self) -> button::Style {
+        button::Style {
+            background: Some(Background::Color(self.0.background)),
+            text_color: Color { ..self.0.primary },
+            border_radius: 2,
+            ..button::Style::default()
+        }
+    }
+
+    fn hovered(&self) -> button::Style {
+        button::Style {
+            background: Some(Background::Color(Color {
+                a: 0.1,
+                ..self.0.primary
+            })),
+            text_color: self.0.primary,
+            ..self.active()
+        }
+    }
+}
+
 pub struct SegmentedButton(pub ColorPalette);
 impl button::StyleSheet for SegmentedButton {
     fn active(&self) -> button::Style {

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -231,6 +231,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             if let Ok(mut addons) = result {
                 // Sort the addons.
                 sort_addons(&mut addons, SortDirection::Desc, SortKey::Status);
+                ajour.sort_state.previous_sort_direction = Some(SortDirection::Desc);
+                ajour.sort_state.previous_sort_key = Some(SortKey::Status);
 
                 if flavor == ajour.config.wow.flavor {
                     // Set the state if flavor matches.


### PR DESCRIPTION
Resolves #94.
This PR improves clarity of the selected row to easily see which is used as a sort key, and which direction.

<img width="883" alt="Screenshot 2020-09-15 at 23 28 41" src="https://user-images.githubusercontent.com/2248455/93267021-4a863880-f7ab-11ea-8a52-0cdf022f5bde.png">

