### PR TITLE
deser old ignored addons format

### DIFF
--- a/src/config/addons.rs
+++ b/src/config/addons.rs
@@ -1,12 +1,12 @@
 use super::Flavor;
-use serde_derive::{Deserialize, Serialize};
+use de::de_ignored;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Struct for addons specific settings.
-#[serde(default)]
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct Addons {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_ignored")]
     pub ignored: HashMap<Flavor, Vec<String>>,
 }
 
@@ -15,5 +15,56 @@ impl Default for Addons {
         Addons {
             ignored: HashMap::new(),
         }
+    }
+}
+
+mod de {
+    use crate::config::Flavor;
+    use serde::{
+        de::{self, MapAccess, SeqAccess, Visitor},
+        Deserialize, Deserializer,
+    };
+    use std::collections::HashMap;
+    use std::fmt;
+
+    pub fn de_ignored<'de, D>(deserializer: D) -> Result<HashMap<Flavor, Vec<String>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct DeIgnored;
+
+        impl<'de> Visitor<'de> for DeIgnored {
+            type Value = HashMap<Flavor, Vec<String>>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("Vec<String> or HashMap<Flavor, Vec<String>>")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut map = HashMap::new();
+                let mut ignored = vec![];
+
+                while let Ok(Some(value)) = seq.next_element::<String>() {
+                    ignored.push(value);
+                }
+
+                map.insert(Flavor::Retail, ignored.clone());
+                map.insert(Flavor::Classic, ignored);
+
+                Ok(map)
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))
+            }
+        }
+
+        deserializer.deserialize_any(DeIgnored)
     }
 }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -235,17 +235,17 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 if flavor == ajour.config.wow.flavor {
                     // Set the state if flavor matches.
                     ajour.state = AjourState::Idle;
-
-                    // Find and push the ignored addons.
-                    let ignored_ids = ajour.config.addons.ignored.entry(flavor).or_default();
-                    let ignored_addons: Vec<_> = addons
-                        .iter()
-                        .filter(|a| ignored_ids.iter().any(|i| i == &a.id))
-                        .map(|a| (a.clone(), button::State::new()))
-                        .collect::<Vec<(Addon, button::State)>>();
-
-                    ajour.ignored_addons.insert(flavor, ignored_addons);
                 }
+
+                // Find and push the ignored addons.
+                let ignored_ids = ajour.config.addons.ignored.entry(flavor).or_default();
+                let ignored_addons: Vec<_> = addons
+                    .iter()
+                    .filter(|a| ignored_ids.iter().any(|i| i == &a.id))
+                    .map(|a| (a.clone(), button::State::new()))
+                    .collect::<Vec<(Addon, button::State)>>();
+
+                ajour.ignored_addons.insert(flavor, ignored_addons);
 
                 // Insert the addons into the HashMap.
                 ajour.addons.insert(flavor, addons);


### PR DESCRIPTION
@casperstorm I got it figured out! Check out the `visit_seq` for the meat of how we handle the old array format. I tested this and it works!

I also noticed that ingored addons in the settings only showed up for the flavor at launch, but if I switched to the other flavor, it didn't show up (unless you hit refresh). I fixed in the ParsedAddons message logic so both flavors have their ignored addons added.