### PR TITLE
feat: on interactions, we close settings if its shown.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 - Made it easier to use Ajour if you play both Classic and Retail by moving the control from settings into the menubar.
   - Ajour will now parse both Classic and Retail directories on launch. This means that when you switch between the two it will now be instantaneously.
 ### Fixed
+- Ignoring an addon, will now correctly clear the last opened addon state.
+  - If you opened details for an addon, and ignored it and unignored it right after it would re-appear as opened. This is now fixed so it will re-appear as closed. 
+- Settings window will now be closed on interactions outside of it.
+  - It was a bit confusing that the settings window stayed open even though you interacted with the application outside of settings. This is now corrected, so any interaction will close the window, if it's open.
 - Better toc file parsing
   - We now have better logic catching the values inside the toc file
   - If we for some reason does not find a title for the addon, we fallback and use the foldername

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -60,6 +60,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             return Ok(Command::batch(commands));
         }
         Message::Interaction(Interaction::Refresh) => {
+            // Close settings if shown.
+            ajour.is_showing_settings = false;
+
             // Cleans the addons.
             ajour.addons = HashMap::new();
 
@@ -72,6 +75,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             ajour.is_showing_settings = !ajour.is_showing_settings;
         }
         Message::Interaction(Interaction::Ignore(id)) => {
+            // Close settings if shown.
+            ajour.is_showing_settings = false;
+
             let flavor = ajour.config.wow.flavor;
             let addons = ajour.addons.entry(flavor).or_default();
             let addon = addons.iter().find(|a| a.id == id);
@@ -81,6 +87,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 let ignored_addon = (addon.clone(), button::State::new());
                 let ignored_addons = ajour.ignored_addons.entry(flavor).or_default();
                 ignored_addons.push(ignored_addon);
+
+                // Remove the expanded addon.
+                ajour.expanded_addon = None;
 
                 // Update the config.
                 ajour
@@ -135,12 +144,16 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
         }
         Message::Interaction(Interaction::FlavorSelected(flavor)) => {
+            // Close settings if shown.
+            ajour.is_showing_settings = false;
             // Update the game flavor
             ajour.config.wow.flavor = flavor;
             // Persist the newly updated config.
             let _ = &ajour.config.save();
         }
         Message::Interaction(Interaction::Expand(id)) => {
+            // Close settings if shown.
+            ajour.is_showing_settings = false;
             // Expand a addon. If it's already expanded, we collapse it again.
             let flavor = ajour.config.wow.flavor;
             let addons = ajour.addons.entry(flavor).or_default();
@@ -158,6 +171,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
         }
         Message::Interaction(Interaction::Delete(id)) => {
+            // Close settings if shown.
+            ajour.is_showing_settings = false;
+
             let flavor = ajour.config.wow.flavor;
             let addons = ajour.addons.entry(flavor).or_default();
 
@@ -179,6 +195,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
         }
         Message::Interaction(Interaction::Update(id)) => {
+            // Close settings if shown.
+            ajour.is_showing_settings = false;
+
             let flavor = ajour.config.wow.flavor;
             let addons = ajour.addons.entry(flavor).or_default();
             let to_directory = ajour
@@ -200,6 +219,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             }
         }
         Message::Interaction(Interaction::UpdateAll) => {
+            // Close settings if shown.
+            ajour.is_showing_settings = false;
+
             // Update all pressed
             let flavor = ajour.config.wow.flavor;
             let addons = ajour.addons.entry(flavor).or_default();
@@ -348,6 +370,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             ajour.needs_update = newer_version;
         }
         Message::Interaction(Interaction::SortColumn(sort_key)) => {
+            // Close settings if shown.
+            ajour.is_showing_settings = false;
+
             // First time clicking a column should sort it in Ascending order, otherwise
             // flip the sort direction.
             let mut sort_direction = SortDirection::Asc;


### PR DESCRIPTION
Resolves #113.

Closes settings on the following interactions:
- [X] Refresh
- [X] Ignore addon
- [X] Switch between the retail/classic lists
- [X] Open/close addon details
- [X] Delete addon
- [X] Update addon
- [X] Update all addons
- [X] Sort the list
