### PR TITLE
fix: now correctly ignores ignored addons when updating all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,23 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 ## [Unreleased]
 ### Added
 - Improve clarity of row titles to reflect current sort state
-  - A little up-, or down-arrow has been added to indicate sort direction, and a color has been added to the selected colum.
-- Added local logging for debugging the application. An `ajour.log` file is saved in the ajour config directory. This file can be shared along with any bug reports to help better debug the issue.
+  - A little up-, or down-arrow has been added to indicate sort direction, and a color has been added to the selected colum
+- Added local logging for debugging the application. An `ajour.log` file is saved in the ajour config directory. This file can be shared along with any bug reports to help better debug the issue
 ### Changed
-- Made it easier to use Ajour if you play both Classic and Retail by moving the control from settings into the menubar.
-  - Ajour will now parse both Classic and Retail directories on launch. This means that when you switch between the two it will now be instantaneously.
+- Made it easier to use Ajour if you play both Classic and Retail by moving the control from settings into the menubar
+  - Ajour will now parse both Classic and Retail directories on launch. This means that when you switch between the two it will now be instantaneously
 ### Fixed
-- Ignoring an addon, will now correctly clear the last opened addon state.
-  - If you opened details for an addon, and ignored it and unignored it right after it would re-appear as opened. This is now fixed so it will re-appear as closed. 
-- Settings window will now be closed on interactions outside of it.
-  - It was a bit confusing that the settings window stayed open even though you interacted with the application outside of settings. This is now corrected, so any interaction will close the window, if it's open.
+- Update all will now respect ignored addons, and correctly skip them
+- Ignoring an addon, will now correctly clear the last opened addon state
+  - If you opened details for an addon, and ignored it and unignored it right after it would re-appear as opened. This is now fixed so it will re-appear as closed
+- Settings window will now be closed on interactions outside of it
+  - It was a bit confusing that the settings window stayed open even though you interacted with the application outside of settings. This is now corrected, so any interaction will close the window, if it's open
 - Better toc file parsing
   - We now have better logic catching the values inside the toc file
   - If we for some reason does not find a title for the addon, we fallback and use the foldername
 - Check for case-insensitive version of `Interface/AddOns` folder for robustness
 - Check for & create ajour config folder before launching concurrent init operations
-  - The `load_config` and `load_user_themes` operations are launched concurrently on startup. Since they both require the config folder, they will both try to create it if it doesn't exist. This causes a panic on linux since the `create_dir` fs operation fails if the folder already exists.
+  - The `load_config` and `load_user_themes` operations are launched concurrently on startup. Since they both require the config folder, they will both try to create it if it doesn't exist. This causes a panic on linux since the `create_dir` fs operation fails if the folder already exists
 
 ## [0.3.2] - 2020-09-11
 ### Changed

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -263,7 +263,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 .addons
                 .entry(flavor)
                 .or_default()
-                .into_iter()
+                .iter_mut()
                 .filter(|a| !ignored_ids.iter().any(|i| i == &a.id))
                 .collect();
 

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -256,9 +256,17 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             // Close settings if shown.
             ajour.is_showing_settings = false;
 
-            // Update all pressed
+            // Update all updatable addons, expect ignored.
             let flavor = ajour.config.wow.flavor;
-            let addons = ajour.addons.entry(flavor).or_default();
+            let ignored_ids = ajour.config.addons.ignored.entry(flavor).or_default();
+            let mut addons: Vec<_> = ajour
+                .addons
+                .entry(flavor)
+                .or_default()
+                .into_iter()
+                .filter(|a| !ignored_ids.iter().any(|i| i == &a.id))
+                .collect();
+
             let mut commands = vec![];
             for addon in addons.iter_mut() {
                 if addon.state == AddonState::Updatable {


### PR DESCRIPTION
## Proposed Changes
  - When pressing update all we also updated ignored addons which is a bug. This is now resolved.

## Checklist

- [X] Tested on all platforms changed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo clippy` has been run on this branch
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
