### PR TITLE
chore: removed remote title

### DIFF
--- a/src/addon.rs
+++ b/src/addon.rs
@@ -29,7 +29,6 @@ pub struct Addon {
     pub version: Option<String>,
     pub remote_version: Option<String>,
     pub remote_url: Option<String>,
-    pub remote_title: Option<String>,
     pub path: PathBuf,
     pub dependencies: Vec<String>,
     pub state: AddonState,
@@ -70,7 +69,6 @@ impl Addon {
             version,
             remote_version: None,
             remote_url: None,
-            remote_title: None,
             path,
             dependencies,
             state: AddonState::Ajour(None),
@@ -93,7 +91,6 @@ impl Addon {
     pub fn apply_tukui_package(&mut self, package: &tukui_api::TukuiPackage) {
         self.remote_version = Some(package.version.clone());
         self.remote_url = Some(package.url.clone());
-        self.remote_title = Some(package.name.clone());
 
         if self.is_updatable() {
             self.state = AddonState::Updatable;

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -132,10 +132,7 @@ pub fn settings_container<'a>(
     }
 
     for (addon, state) in ignored_addons {
-        let title = addon
-            .remote_title
-            .clone()
-            .unwrap_or_else(|| addon.title.clone());
+        let title = addon.title.clone();
         let title_text = Text::new(title).size(14);
         let title_container = Container::new(title_text)
             .height(Length::Units(26))


### PR DESCRIPTION
## Proposed Changes
  - `remote_title` was not really used anymore, but it was the first priority when choosing name for the ignored addon in settings. This has now been corrected, and the variable is removed. 

## Checklist

- [X] Tested on all platforms changed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo clippy` has been run on this branch
