### PR TITLE
feat: highlight selected addon and close details on interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,14 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
   - A little up-, or down-arrow has been added to indicate sort direction, and a color has been added to the selected colum.
 - Added local logging for debugging the application. An `ajour.log` file is saved in the ajour config directory. This file can be shared along with any bug reports to help better debug the issue.
 ### Changed
+- When displaying details for an addon, the title of the addon is highlighted to improve visibility of which addon is expanded.
 - Made it easier to use Ajour if you play both Classic and Retail by moving the control from settings into the menubar.
   - Ajour will now parse both Classic and Retail directories on launch. This means that when you switch between the two it will now be instantaneously.
 ### Fixed
 - Ignoring an addon, will now correctly clear the last opened addon state.
   - If you opened details for an addon, and ignored it and unignored it right after it would re-appear as opened. This is now fixed so it will re-appear as closed. 
-- Settings window will now be closed on interactions outside of it.
-  - It was a bit confusing that the settings window stayed open even though you interacted with the application outside of settings. This is now corrected, so any interaction will close the window, if it's open.
+- Settings and details window will now be closed on interactions outside of it.
+  - It was a bit confusing that the these windows stayed open even though you interacted with the application outside of it. This is now corrected, so any interaction will close them. 
 - Better toc file parsing
   - We now have better logic catching the values inside the toc file
   - If we for some reason does not find a title for the addon, we fallback and use the foldername

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -191,10 +191,16 @@ pub fn addon_data_cell(
         .unwrap_or_else(|| String::from("-"));
 
     let title = Text::new(&addon.title).size(DEFAULT_FONT_SIZE);
-    let title_button: Element<Interaction> = Button::new(&mut addon.details_btn_state, title)
-        .on_press(Interaction::Expand(addon.id.clone()))
-        .style(style::TextButton(color_palette))
-        .into();
+    let mut title_button = Button::new(&mut addon.details_btn_state, title)
+        .on_press(Interaction::Expand(addon.id.clone()));
+
+    if is_addon_expanded {
+        title_button = title_button.style(style::SelectedTextButton(color_palette));
+    } else {
+        title_button = title_button.style(style::TextButton(color_palette));
+    }
+
+    let title_button: Element<Interaction> = title_button.into();
 
     let title_container = Container::new(title_button.map(Message::Interaction))
         .height(default_height)

--- a/src/gui/style.rs
+++ b/src/gui/style.rs
@@ -20,6 +20,25 @@ impl button::StyleSheet for TextButton {
     }
 }
 
+pub struct SelectedTextButton(pub ColorPalette);
+impl button::StyleSheet for SelectedTextButton {
+    fn active(&self) -> button::Style {
+        button::Style {
+            text_color: self.0.primary,
+            border_radius: 2,
+            ..button::Style::default()
+        }
+    }
+
+    fn hovered(&self) -> button::Style {
+        button::Style {
+            background: Some(Background::Color(Color::TRANSPARENT)),
+            text_color: self.0.primary,
+            ..self.active()
+        }
+    }
+}
+
 pub struct DefaultButton(pub ColorPalette);
 impl button::StyleSheet for DefaultButton {
     fn active(&self) -> button::Style {

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -74,6 +74,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
 
             // Close settings if shown.
             ajour.is_showing_settings = false;
+            // Close details if shown.
+            ajour.expanded_addon = None;
 
             // Cleans the addons.
             ajour.addons = HashMap::new();
@@ -87,12 +89,17 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             log::debug!("Interaction::Settings");
 
             ajour.is_showing_settings = !ajour.is_showing_settings;
+
+            // Remove the expanded addon.
+            ajour.expanded_addon = None;
         }
         Message::Interaction(Interaction::Ignore(id)) => {
             log::debug!("Interaction::Ignore({})", &id);
 
             // Close settings if shown.
             ajour.is_showing_settings = false;
+            // Close details if shown.
+            ajour.expanded_addon = None;
 
             let flavor = ajour.config.wow.flavor;
             let addons = ajour.addons.entry(flavor).or_default();
@@ -103,9 +110,6 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 let ignored_addon = (addon.clone(), button::State::new());
                 let ignored_addons = ajour.ignored_addons.entry(flavor).or_default();
                 ignored_addons.push(ignored_addon);
-
-                // Remove the expanded addon.
-                ajour.expanded_addon = None;
 
                 // Update the config.
                 ajour
@@ -172,6 +176,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
 
             // Close settings if shown.
             ajour.is_showing_settings = false;
+            // Close details if shown.
+            ajour.expanded_addon = None;
             // Update the game flavor
             ajour.config.wow.flavor = flavor;
             // Persist the newly updated config.
@@ -182,6 +188,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
 
             // Close settings if shown.
             ajour.is_showing_settings = false;
+
             // Expand a addon. If it's already expanded, we collapse it again.
             let flavor = ajour.config.wow.flavor;
             let addons = ajour.addons.entry(flavor).or_default();
@@ -203,6 +210,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
 
             // Close settings if shown.
             ajour.is_showing_settings = false;
+            // Close details if shown.
+            ajour.expanded_addon = None;
 
             let flavor = ajour.config.wow.flavor;
             let addons = ajour.addons.entry(flavor).or_default();
@@ -229,6 +238,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
 
             // Close settings if shown.
             ajour.is_showing_settings = false;
+            // Close details if shown.
+            ajour.expanded_addon = None;
 
             let flavor = ajour.config.wow.flavor;
             let addons = ajour.addons.entry(flavor).or_default();
@@ -255,6 +266,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
 
             // Close settings if shown.
             ajour.is_showing_settings = false;
+            // Close details if shown.
+            ajour.expanded_addon = None;
 
             // Update all pressed
             let flavor = ajour.config.wow.flavor;
@@ -434,6 +447,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
         Message::Interaction(Interaction::SortColumn(sort_key)) => {
             // Close settings if shown.
             ajour.is_showing_settings = false;
+            // Close details if shown.
+            ajour.expanded_addon = None;
 
             // First time clicking a column should sort it in Ascending order, otherwise
             // flip the sort direction.


### PR DESCRIPTION
## Proposed Changes
  - Interactions will now close details view.
  - Highlighted title of expanded addon.

## Checklist

- [X] Tested on all platforms changed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo clippy` has been run on this branch
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
