### PR TITLE
feat: bundle dynlibs for x86_64

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,4 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]
+[target.i686-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -7,15 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` and `Removed`.
 
 ## [Unreleased]
-## [0.3.3] - 2020-09-17
+
 ### Packaging
+
+- Windows: Ajour now comes bundled with the needed dependencies. This way we avoid relying on the system having Microsoft Visual C++ 2015 Redistributable.
+
+## [0.3.3] - 2020-09-17
+
+### Packaging
+
 - Added local logging for debugging the application. An `ajour.log` file is saved in the ajour config directory. This file can be shared along with any bug reports to help better debug the issue
+
 ### Added
+
 - Improve clarity of row titles to reflect current sort state
+
 ### Changed
+
 - Made it easier to use Ajour if you play both Classic and Retail by moving the control from settings into the menubar
   - Ajour will now parse both Classic and Retail directories on launch. This means that when you switch between the two it will now be instantaneously
+
 ### Fixed
+
 - Update all will now respect ignored addons, and correctly skip them
 - The settings- and detail-window will now be closed on interactions outside of it
   - It was a bit confusing that the windows stayed open even though you interacted with the application outside of them
@@ -28,61 +42,90 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
   - The `load_config` and `load_user_themes` operations are launched concurrently on startup. Since they both require the config folder, they will both try to create it if it doesn't exist. This causes a panic on linux since the `create_dir` fs operation fails if the folder already exists
 
 ## [0.3.2] - 2020-09-11
+
 ### Changed
+
 - Light theme is now a bit more gentle to the eyes. Don't worry, it's still not default.
 - Switched Refresh and Update All buttons.
 
 ## [0.3.1] - 2020-09-11
+
 ### Fixed
+
 - Correctly rehashes addon after an update.
   - After an addon was updated we did in some cases not rehash correctly. This was due to the fact that a addon can have multiple folders and this was not taken into account in this case. Another case was that we replaced the content with the new update, but that could again lead to a miscalclulated hash if there was a mismatch in amount of files. Thanks to [tarkah](https://github.com/tarkah) for these optimizations.
 
 ## [0.3.0] - 2020-09-10
+
 ### Added
+
 - Fingerprinting is now used to better match addons.
   - This is a bigger refactor, which introduces a whole new way of matching addons. We are now doing a hash of each addon, which we then compare with the API to see if we need to update or not. It has, however, introduced a longer initial load time because we need to hash each addon. The hash is saved locally, so we have some logic in place to minimize the amount of times we are hashing.
+
 ### Fixed
+
 - Trimming leading and trailing whitespace from toc values.
-  - Small issue where some `.toc` files added multiple space before, or after values which would confuse our UI. 
+  - Small issue where some `.toc` files added multiple space before, or after values which would confuse our UI.
 - UI glitch in settings has been removed.
+
 ## [0.2.5] - 2020-09-05
+
 ### Added
+
 - Make columns sortable (by [tarkah](https://github.com/tarkah))
 - Support for user themes and theme selection (by [tarkah](https://github.com/tarkah))
+
 ### Fixed
+
 - UTF-8 issue in .toc file
 - Updated copy, and improved onboarding experience
+
 ## [0.2.4] - 2020-09-02
+
 ### Added
+
 - Ajour checks itself for updates (by [tarkah](https://github.com/tarkah))
 - Tukui now handle classic flavor
+
 ### Changed
+
 - Removed details button. Title is now clickable.
+
 ### Fixed
+
 - Parsing issue with Tukui addons.
 
 ## [0.2.3] - 2020-08-30
+
 ### Added
+
 - New logic for bundling together addons
 - Author information in addon details
 - Ignore and unignore addons
 
 ### Changed
+
 - Throttle # of connections to api
 
 ## [0.2.2] - 2020-08-27
+
 ### Added
+
 - Select game flavor in Settings
 
 ### Fixed
+
 - Large addons were not being timedout
 - Linux users were not able to select a folder in file dialog
 
 ## [0.2.1] - 2020-08-26
+
 ### Added
+
 - Settings view
 - File dialog to select World of Warcraft pth from settings view
 - Force download button on addons
 
 ### Fixed
+
 - Better copy for many strings


### PR DESCRIPTION
## Proposed Changes

On Windows Ajour depends on Microsoft Visual C++ 2015 Redistributable being installed. If you don't have it installed, you would get an error, eg. `VCRUNTIME140_1.dll is missing`. 

I have now adjusted the build setup, so all dependencies are bundled together inside the executable. From my initial testing the size of the Ajour is still below 10mb, and still only consists of the executable, no extra files.

## Checklist

- [X] Tested on all platforms changed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo clippy` has been run on this branch
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
