### PR TITLE
Add install md to indicate app bin

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -60,6 +60,12 @@ If your system has extra dependencies, and they are not listed here please creat
 cargo build --release
 ```
 
+The application executable will be built to
+
+```sh
+target/release/ajour
+``` 
+
 ### macOS
 
 ```sh


### PR DESCRIPTION
_disclaimer: I'm very new to contributing to open source projects. Any feedback regarding my contribution is welcome and appreciated!_

## Context for changes
I am a new Linux user and have been experimenting with gaming on Linux. Since the Twitch app was not easy to get up and running with Wine, I stumbled across this app and was excited! After following the INSTALL.md and due to my unfamiliarity with Rust apps, I had a hard time finding the compiled binary.

## Proposed Changes
  - Adds some clarifying markdown to indicate where the final binary is built to for Windows and Linux users.

## Checklist

- [n/a] Tested on all platforms changed
- [n/a] `cargo fmt` has been run on this branch
- [n/a] `cargo clippy` has been run on this branch
- [n/a] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
