### PR TITLE
add scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
   - The idea is that with this button, it is easy to open up the addon website and view additional information which Ajour might not show.
 - Columns can be resized by clicking & dragging the dividers between the column headers. This change will be saved and used when starting Ajour.
 - Window size will be saved when resizing the application and used when starting Ajour.
+- UI Scaling has been added to settings. UI scale can be increased or decreased and will be saved when changed.
 
 ### Changed
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -26,6 +26,8 @@ pub struct Config {
     pub column_config: ColumnConfig,
 
     pub window_size: Option<(u32, u32)>,
+
+    pub scale: Option<f64>,
 }
 
 impl Config {

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -94,7 +94,7 @@ pub fn settings_container<'a>(
 
     // Scale buttons for application scale factoring.
     let (scale_title_row, scale_buttons_row) = {
-        let scale_title = Text::new("Scale").size(DEFAULT_FONT_SIZE);
+        let scale_title = Text::new("UI Scale").size(DEFAULT_FONT_SIZE);
         let scale_title_row = Row::new().push(scale_title).padding(DEFAULT_PADDING);
 
         let scale_down_button: Element<Interaction> = Button::new(

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -51,6 +51,8 @@ pub enum Interaction {
     SortColumn(SortKey),
     FlavorSelected(Flavor),
     ResizeColumn(header::ResizeEvent),
+    ScaleUp,
+    ScaleDown,
 }
 
 #[derive(Debug)]
@@ -91,6 +93,7 @@ pub struct Ajour {
     fingerprint_collection: Arc<Mutex<Option<FingerprintCollection>>>,
     retail_btn_state: button::State,
     classic_btn_state: button::State,
+    scale_state: ScaleState,
 }
 
 impl Default for Ajour {
@@ -122,6 +125,7 @@ impl Default for Ajour {
             fingerprint_collection: Arc::new(Mutex::new(None)),
             retail_btn_state: Default::default(),
             classic_btn_state: Default::default(),
+            scale_state: Default::default(),
         }
     }
 }
@@ -143,6 +147,10 @@ impl Application for Ajour {
 
     fn title(&self) -> String {
         String::from("Ajour")
+    }
+
+    fn scale_factor(&self) -> f64 {
+        self.scale_state.scale
     }
 
     fn subscription(&self) -> Subscription<Self::Message> {
@@ -260,6 +268,7 @@ impl Application for Ajour {
                 ignored_addons,
                 &cloned_config,
                 &mut self.theme_state,
+                &mut self.scale_state,
             );
 
             // Space below settings.
@@ -421,6 +430,22 @@ impl Default for ThemeState {
             themes,
             current_theme_name: "Dark".to_string(),
             pick_list_state: Default::default(),
+        }
+    }
+}
+
+pub struct ScaleState {
+    scale: f64,
+    up_btn_state: button::State,
+    down_btn_state: button::State,
+}
+
+impl Default for ScaleState {
+    fn default() -> Self {
+        ScaleState {
+            scale: 1.0,
+            up_btn_state: Default::default(),
+            down_btn_state: Default::default(),
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/casperstorm/ajour/projects/2#card-45378181

This adds the ability to specify application scale in the settings & persists that change to the config. Overall an easy change since `Iced` provides a scale factor on the application so we don't have to manually scale anything.