### PR TITLE
backup feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 - Columns can be resized by clicking & dragging the dividers between the column headers. This change will be saved and used when starting Ajour.
 - Window size will be saved when resizing the application and used when starting Ajour.
 - UI Scaling has been added to settings. UI scale can be increased or decreased and will be saved when changed.
+- A backup option has been added to archive the AddOns and WTF folders from each flavor installed on the machine to a user chosen directory.
+  - Backups created through Ajour are not actively managed once created, so pruning old backups and restoring from a backup need to be handled by the user
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "timeago",
+ "walkdir",
  "widgets",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ chrono = "0.4"
 log = "0.4"
 fern = "0.6"
 timeago = "0.2.1"
+walkdir = "2.3"
 
 widgets = { path = "crates/widgets" }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,6 +28,8 @@ pub struct Config {
     pub window_size: Option<(u32, u32)>,
 
     pub scale: Option<f64>,
+
+    pub backup_directory: Option<PathBuf>,
 }
 
 impl Config {

--- a/src/fs/backup.rs
+++ b/src/fs/backup.rs
@@ -1,0 +1,139 @@
+use crate::error::ClientError;
+use crate::Result;
+
+use std::fs::File;
+use std::io::{BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+use zip::{write::FileOptions, CompressionMethod, ZipWriter};
+
+pub trait Backup {
+    fn backup(&self) -> Result<()>;
+}
+
+pub struct BackupFolder {
+    path: PathBuf,
+    prefix: PathBuf,
+}
+
+impl BackupFolder {
+    fn new(path: impl AsRef<Path>, prefix: impl AsRef<Path>) -> BackupFolder {
+        BackupFolder {
+            path: path.as_ref().to_owned(),
+            prefix: prefix.as_ref().to_owned(),
+        }
+    }
+}
+
+pub struct ZipBackup {
+    src: Vec<BackupFolder>,
+    dest: PathBuf,
+}
+
+impl ZipBackup {
+    pub fn new(src: Vec<BackupFolder>, dest: impl AsRef<Path>) -> ZipBackup {
+        ZipBackup {
+            src,
+            dest: dest.as_ref().to_owned(),
+        }
+    }
+}
+
+impl Backup for ZipBackup {
+    fn backup(&self) -> Result<()> {
+        let output = BufWriter::new(File::create(&self.dest)?);
+
+        let mut zip_writer = ZipWriter::new(output);
+        let options = FileOptions::default()
+            .compression_method(CompressionMethod::Bzip2)
+            .unix_permissions(0o755);
+
+        let mut buffer = vec![];
+
+        for folder in &self.src {
+            let prefix = &folder.prefix;
+            let path = &folder.path;
+
+            zip_write(path, prefix, &mut buffer, &mut zip_writer, options)?;
+
+            for entry in WalkDir::new(path)
+                .into_iter()
+                .filter_map(std::result::Result::ok)
+            {
+                let path = entry.path();
+
+                zip_write(path, prefix, &mut buffer, &mut zip_writer, options)?;
+            }
+        }
+
+        zip_writer.finish()?;
+
+        Ok(())
+    }
+}
+
+fn zip_write(
+    path: &Path,
+    prefix: &Path,
+    buffer: &mut Vec<u8>,
+    writer: &mut ZipWriter<BufWriter<File>>,
+    options: FileOptions,
+) -> Result<()> {
+    if !path.exists() {
+        return Err(ClientError::Custom(format!(
+            "path doesn't exist while backing up folder: {:?}",
+            path
+        )));
+    }
+
+    let name = path.strip_prefix(prefix).unwrap().to_str().unwrap();
+
+    if path.is_dir() {
+        writer.add_directory(name, options)?;
+    } else {
+        writer.start_file(name, options)?;
+
+        let mut file = File::open(path)?;
+        file.read_to_end(buffer)?;
+
+        writer.write_all(buffer)?;
+        buffer.clear();
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, Flavor};
+    use crate::fs::PersistentData;
+    use chrono::Local;
+
+    #[test]
+    fn test_zip_backup() {
+        let config: Config = Config::load().unwrap();
+
+        let mut src_folders = vec![];
+
+        let wow_dir = config.wow.directory.as_ref().unwrap();
+
+        for flavor in Flavor::ALL.iter() {
+            let addon_dir = config.get_addon_directory_for_flavor(flavor).unwrap();
+            let wtf_dir = config.get_wtf_directory_for_flavor(flavor).unwrap();
+
+            src_folders.push(BackupFolder::new(&addon_dir, wow_dir));
+            src_folders.push(BackupFolder::new(&wtf_dir, wow_dir));
+        }
+
+        let now = Local::now();
+        let dest = format!(
+            "C:\\TempPath\\ajour_backup_{}.zip",
+            now.format("%Y-%m-%d_%H-%M-%S")
+        );
+
+        let zip_backup = ZipBackup::new(src_folders, dest);
+
+        zip_backup.backup().unwrap();
+    }
+}

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::{fs, path::PathBuf};
 
 mod addon;
+mod backup;
 mod save;
 mod theme;
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::{fs, path::PathBuf};
 
 mod addon;
-mod backup;
+pub mod backup;
 mod save;
 mod theme;
 

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -310,7 +310,7 @@ pub fn settings_container<'a>(
         .push(Space::new(Length::Fill, Length::Units(DEFAULT_PADDING)));
     let right_container = Container::new(right_column)
         .width(Length::FillPortion(1))
-        .height(Length::Units(240))
+        .height(Length::Units(245))
         .style(style::AddonRowDefaultTextContainer(color_palette));
 
     // Row to wrap each section.

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -13,6 +13,7 @@ use crate::{
     Result,
 };
 use async_std::sync::{Arc, Mutex};
+use chrono::NaiveDateTime;
 use iced::{
     button, pick_list, scrollable, Application, Column, Command, Container, Element, Length,
     Settings, Space, Subscription,
@@ -41,7 +42,7 @@ pub enum Interaction {
     Delete(String),
     Expand(String),
     Ignore(String),
-    OpenDirectory,
+    OpenDirectory(DirectoryType),
     OpenLink(String),
     Refresh,
     Settings,
@@ -53,6 +54,7 @@ pub enum Interaction {
     ResizeColumn(header::ResizeEvent),
     ScaleUp,
     ScaleDown,
+    Backup,
 }
 
 #[derive(Debug)]
@@ -68,8 +70,11 @@ pub enum Message {
     ThemeSelected(String),
     ThemesLoaded(Vec<Theme>),
     UnpackedAddon((String, Result<()>)),
-    UpdateDirectory(Option<PathBuf>),
+    UpdateWowDirectory(Option<PathBuf>),
+    UpdateBackupDirectory(Option<PathBuf>),
     RuntimeEvent(iced_native::Event),
+    LatestBackup(Option<NaiveDateTime>),
+    BackupFinished(Result<NaiveDateTime>),
 }
 
 pub struct Ajour {
@@ -94,6 +99,7 @@ pub struct Ajour {
     retail_btn_state: button::State,
     classic_btn_state: button::State,
     scale_state: ScaleState,
+    backup_state: BackupState,
 }
 
 impl Default for Ajour {
@@ -126,6 +132,7 @@ impl Default for Ajour {
             retail_btn_state: Default::default(),
             classic_btn_state: Default::default(),
             scale_state: Default::default(),
+            backup_state: Default::default(),
         }
     }
 }
@@ -269,6 +276,7 @@ impl Application for Ajour {
                 &cloned_config,
                 &mut self.theme_state,
                 &mut self.scale_state,
+                &mut self.backup_state,
             );
 
             // Space below settings.
@@ -348,6 +356,12 @@ pub fn run() {
 
     // Runs the GUI.
     Ajour::run(settings);
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum DirectoryType {
+    Wow,
+    Backup,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Hash, Eq)]
@@ -448,4 +462,12 @@ impl Default for ScaleState {
             down_btn_state: Default::default(),
         }
     }
+}
+
+#[derive(Default)]
+pub struct BackupState {
+    backing_up: bool,
+    last_backup: Option<NaiveDateTime>,
+    directory_btn_state: button::State,
+    backup_now_btn_state: button::State,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod addon;
+mod backup;
 mod config;
 mod curse_api;
 mod error;


### PR DESCRIPTION
This feature will allow the user to backup their Addons and WTF folder through Ajour. Once the user selects a backup directory in settings, a "Backup Now" button will be available to push. Once clicked, the app will zip the Addons and WTF folders from each flavor present on the system and save that zip file under the backup folder with name `ajour_backup_YYYY-MM-DD_HH-MM-SS.zip`. We can then parse this folder on startup and determine the most recent backup made by the user and present that datetime along with the Backup Now button.

This won't manage the backups once they are created, so it won't handle pruning old backups or restoring from backups.