### PR TITLE
chore: changed ui-scales to 0.1

### DIFF
--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -557,7 +557,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
         Message::Interaction(Interaction::ScaleUp) => {
             let prev_scale = ajour.scale_state.scale;
 
-            ajour.scale_state.scale = (prev_scale + 0.25).min(2.0);
+            ajour.scale_state.scale = (prev_scale + 0.1).min(2.0);
 
             ajour.config.scale = Some(ajour.scale_state.scale);
             let _ = ajour.config.save();
@@ -571,7 +571,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
         Message::Interaction(Interaction::ScaleDown) => {
             let prev_scale = ajour.scale_state.scale;
 
-            ajour.scale_state.scale = (prev_scale - 0.25).max(0.5);
+            ajour.scale_state.scale = (prev_scale - 0.1).max(0.5);
 
             ajour.config.scale = Some(ajour.scale_state.scale);
             let _ = ajour.config.save();


### PR DESCRIPTION
## Proposed Changes
Changes UI scale slider from `0.25` to `0.1`.

## Checklist

- [X] Tested on all platforms changed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo clippy` has been run on this branch
