### PR TITLE
chore: changed compression to deflated

### DIFF
--- a/src/fs/backup.rs
+++ b/src/fs/backup.rs
@@ -34,7 +34,7 @@ impl Backup for ZipBackup {
 
         let mut zip_writer = ZipWriter::new(output);
         let options = FileOptions::default()
-            .compression_method(CompressionMethod::Bzip2)
+            .compression_method(CompressionMethod::Deflated)
             .unix_permissions(0o755);
 
         let mut buffer = vec![];


### PR DESCRIPTION
## Proposed Changes
Changed compression method from `Bzip2` to `Deflated` because both Windows and macOS can't handle `Bzip2` with their default unarchivers. 

## Checklist

- [X] Tested on all platforms changed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo clippy` has been run on this branch
