### PR TITLE
fix: missing dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ version = "0.3.3"
 dependencies = [
  "async-std",
  "chrono",
+ "dirs 3.0.1",
  "fancy-regex",
  "fern",
  "glob",
@@ -668,6 +669,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,7 +853,7 @@ dependencies = [
  "core-foundation 0.7.0",
  "core-graphics",
  "core-text",
- "dirs",
+ "dirs 2.0.2",
  "dwrote",
  "float-ord",
  "freetype",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -27,6 +27,7 @@ name = "parse_toc"
 regex = "1.3.9"
 fancy-regex = "0.3.5" # Regex with backtracking
 async-std = "1.6.2"
+dirs = "3.0"
 serde = { version = "1.0.114", features=['derive'] }
 serde_yaml = "0.8.13"
 serde_json = "1.0.57"


### PR DESCRIPTION
Oops, I did the lib split on my linux desktop and accidently removed `dirs` as a dependency due to conditional compilation. Just caught it this morning on my windows work computer.
