### PR TITLE
fix: creates config dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 - You can now select which release channel you want each addon to use. Currently `alpha`, `beta` and `stable` is supported.
 
+### Fixed
+
+- Ajour now creates the `.config` dir if it does not exist on macOS and Linux.
+  - This fixes a crash where Ajour coudn't start if the user didn't have a `.config` directory.
+
 ## [0.3.4] - 2020-09-26
 ### Packaging
 

--- a/crates/core/src/fs/mod.rs
+++ b/crates/core/src/fs/mod.rs
@@ -24,7 +24,7 @@ pub fn config_dir() -> PathBuf {
     let config_dir = PathBuf::from(&home).join(".config/ajour");
 
     if !config_dir.exists() {
-        fs::create_dir(&config_dir).expect("could not create folder $HOME/.config/ajour");
+        fs::create_dir_all(&config_dir).expect("could not create folder $HOME/.config/ajour");
         log::debug!("config directory created");
     }
 


### PR DESCRIPTION
## Proposed Changes
  - If you have a brand new macOS installation there is a chance you dont have the `.config` folder in `~`. If you don't have this folder, Ajour can't start.
  - I have fixed this by creating the folder, if it isn't there.

## Checklist

- [X] Tested on all platforms changed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo clippy` has been run on this branch
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
