### PR TITLE
missing conditional feature attribute

### DIFF
--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -162,6 +162,7 @@ impl Addon {
             unignore_btn_state: Default::default(),
             #[cfg(feature = "gui")]
             website_btn_state: Default::default(),
+            #[cfg(feature = "gui")]
             pick_release_channel_state: Default::default(),
         }
     }


### PR DESCRIPTION
This conditional attribute was missing and causing compilation errors for the `bins` under `ajour-core`
