### PR TITLE
feat: reworked the segmented flavor control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 - You can now select which release channel you want each addon to use. Currently `alpha`, `beta` and `stable` is supported.
 
+### Changed
+- Reworked the controls for selected flavor. It should now be more obvious what is selected and what you can select.
+
 ### Fixed
 
 - Ajour now creates the `.config` dir if it does not exist on macOS and Linux.

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -828,22 +828,28 @@ pub fn menu_container<'a>(
         retail_btn_state,
         Text::new("Retail").size(DEFAULT_FONT_SIZE),
     )
-    .style(style::SegmentedButton(color_palette));
+    .style(style::SegmentedDisabledButton(color_palette))
+    .on_press(Interaction::FlavorSelected(Flavor::Retail));
 
     let mut classic_button = Button::new(
         classic_btn_state,
         Text::new("Classic").size(DEFAULT_FONT_SIZE),
     )
-    .style(style::SegmentedButton(color_palette));
+    .style(style::SegmentedDisabledButton(color_palette))
+    .on_press(Interaction::FlavorSelected(Flavor::Classic));
 
     if !ajour_performing_actions && !ajour_welcome {
         match config.wow.flavor {
             Flavor::Retail => {
+                retail_button = retail_button.style(style::SegmentedSelectedButton(color_palette));
                 classic_button =
-                    classic_button.on_press(Interaction::FlavorSelected(Flavor::Classic));
+                    classic_button.style(style::SegmentedUnselectedButton(color_palette));
             }
             Flavor::Classic => {
-                retail_button = retail_button.on_press(Interaction::FlavorSelected(Flavor::Retail));
+                classic_button =
+                    classic_button.style(style::SegmentedSelectedButton(color_palette));
+                retail_button =
+                    retail_button.style(style::SegmentedUnselectedButton(color_palette));
             }
         }
     }
@@ -853,7 +859,8 @@ pub fn menu_container<'a>(
 
     let segmented_flavor_control_container = Row::new()
         .push(retail_button.map(Message::Interaction))
-        .push(classic_button.map(Message::Interaction));
+        .push(classic_button.map(Message::Interaction))
+        .spacing(0);
 
     // Displays text depending on the state of the app.
     let flavor = config.wow.flavor;

--- a/src/gui/style.rs
+++ b/src/gui/style.rs
@@ -205,8 +205,81 @@ impl button::StyleSheet for SelectedColumnHeaderButton {
     }
 }
 
-pub struct SegmentedButton(pub ColorPalette);
-impl button::StyleSheet for SegmentedButton {
+pub struct SegmentedDisabledButton(pub ColorPalette);
+impl button::StyleSheet for SegmentedDisabledButton {
+    fn active(&self) -> button::Style {
+        button::Style {
+            background: Some(Background::Color(Color::TRANSPARENT)),
+            text_color: Color {
+                a: 0.1,
+                ..self.0.primary
+            },
+            border_radius: 2,
+            border_width: 0,
+            border_color: Color {
+                a: 0.1,
+                ..self.0.primary
+            },
+            ..button::Style::default()
+        }
+    }
+
+    fn hovered(&self) -> button::Style {
+        button::Style { ..self.active() }
+    }
+
+    fn disabled(&self) -> button::Style {
+        button::Style { ..self.active() }
+    }
+}
+
+pub struct SegmentedUnselectedButton(pub ColorPalette);
+impl button::StyleSheet for SegmentedUnselectedButton {
+    fn active(&self) -> button::Style {
+        button::Style {
+            background: Some(Background::Color(Color::TRANSPARENT)),
+            text_color: Color {
+                a: 0.5,
+                ..self.0.primary
+            },
+            border_radius: 2,
+            border_width: 0,
+            border_color: Color {
+                a: 0.1,
+                ..self.0.primary
+            },
+            ..button::Style::default()
+        }
+    }
+
+    fn hovered(&self) -> button::Style {
+        button::Style {
+            background: Some(Background::Color(Color {
+                a: 0.03,
+                ..self.0.primary
+            })),
+            text_color: self.0.primary,
+            ..self.active()
+        }
+    }
+
+    fn disabled(&self) -> button::Style {
+        button::Style {
+            background: Some(Background::Color(Color {
+                a: 0.01,
+                ..self.0.primary
+            })),
+            text_color: Color {
+                a: 0.1,
+                ..self.0.primary
+            },
+            ..self.active()
+        }
+    }
+}
+
+pub struct SegmentedSelectedButton(pub ColorPalette);
+impl button::StyleSheet for SegmentedSelectedButton {
     fn active(&self) -> button::Style {
         button::Style {
             background: Some(Background::Color(Color {
@@ -215,6 +288,8 @@ impl button::StyleSheet for SegmentedButton {
             })),
             text_color: self.0.primary,
             border_radius: 2,
+            border_width: 0,
+            border_color: Color::TRANSPARENT,
             ..button::Style::default()
         }
     }
@@ -222,7 +297,7 @@ impl button::StyleSheet for SegmentedButton {
     fn hovered(&self) -> button::Style {
         button::Style {
             background: Some(Background::Color(Color {
-                a: 0.1,
+                a: 0.03,
                 ..self.0.primary
             })),
             text_color: self.0.primary,


### PR DESCRIPTION
## Proposed Changes
  - We have reworked the segmented controls for selecting classic and retail. This new control should be more obvious for the user.

## Checklist

- [X] Tested on all platforms changed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo clippy` has been run on this branch
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
