### PR TITLE
chore: added small border to segmented control

### DIFF
--- a/src/gui/style.rs
+++ b/src/gui/style.rs
@@ -243,9 +243,9 @@ impl button::StyleSheet for SegmentedUnselectedButton {
                 ..self.0.primary
             },
             border_radius: 2,
-            border_width: 0,
+            border_width: 1,
             border_color: Color {
-                a: 0.1,
+                a: 0.03,
                 ..self.0.primary
             },
             ..button::Style::default()


### PR DESCRIPTION
## Proposed Changes
  - Small border to unselected segmented control to add a better indication that you can press it.