### PR TITLE
fix: the horsepower bug is now fixed 🐴

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 - Ajour now creates the `.config` dir if it does not exist on macOS and Linux.
   - This fixes a crash where Ajour coudn't start if the user didn't have a `.config` directory.
+- Fixed a issue where Ajour would crash if CurseForge returned Minecraft addons instead of a World of Warcraft addons.
+  - We have had a incident where a requested World of Warcraft addon was returned as a Minecraft plugin called HorsePower. This we did not expect so Ajour would crash. 
 
 ## [0.3.4] - 2020-09-26
 ### Packaging

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -217,7 +217,8 @@ impl Addon {
 
         let flavor = format!("wow_{}", flavor.to_string());
         for file in info.latest_files.iter() {
-            if !file.is_alternate && file.game_version_flavor == flavor {
+            let game_version_flavor = file.game_version_flavor.as_ref();
+            if !file.is_alternate && game_version_flavor == Some(&flavor) {
                 let version = file.display_name.clone();
                 let download_url = file.download_url.clone();
                 let date_time = DateTime::parse_from_rfc3339(&file.file_date)

--- a/crates/core/src/curse_api.rs
+++ b/crates/core/src/curse_api.rs
@@ -27,7 +27,7 @@ pub struct File {
     pub file_date: String,
     pub download_url: String,
     pub release_type: u32,
-    pub game_version_flavor: String,
+    pub game_version_flavor: Option<String>,
     pub modules: Vec<Module>,
     pub is_alternate: bool,
     pub game_version_date_released: String,

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -306,7 +306,17 @@ pub async fn read_addon_directory<P: AsRef<Path>>(
     );
 
     // Fetches fingerprint package from curse_api
-    let fingerprint_package = fetch_remote_packages_by_fingerprint(&fingerprint_hashes).await?;
+    let mut fingerprint_package = fetch_remote_packages_by_fingerprint(&fingerprint_hashes).await?;
+
+    // We had a case where a addon hash returned a minecraft addon.
+    // So we filter out all matches which does not have a valid flavor.
+    fingerprint_package
+        .partial_matches
+        .retain(|a| a.file.game_version_flavor.is_some());
+
+    fingerprint_package
+        .exact_matches
+        .retain(|a| a.file.game_version_flavor.is_some());
 
     // Log info about partial matches
     {


### PR DESCRIPTION
## Proposed Changes
For some reason CurseForge returns the a Minecraft addon called HorsePower when we hand them the hash of ActionValue addon. This caused Ajour to crash. I am now filtering out the responses so we don't get this crash in the future. Strange.

## Checklist

- [X] Tested on all platforms changed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo clippy` has been run on this branch
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
