### PR TITLE
include ajour_core in logging

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,8 @@ fn setup_logger() -> Result<()> {
         })
         .level(log::LevelFilter::Off)
         .level_for("panic", log::LevelFilter::Error)
-        .level_for("ajour", log::LevelFilter::Trace);
+        .level_for("ajour", log::LevelFilter::Trace)
+        .level_for("ajour_core", log::LevelFilter::Trace);
 
     #[cfg(debug_assertions)]
     {


### PR DESCRIPTION
@casperstorm I think this was the regression you were referring to. When we created `ajour-core`, we never updated our log filter to capture log events from that library