### PR TITLE
chore: removed antialiasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 ### Fixed
 
+- Fixed a issue where Ajour would start without showing any text.
 - Ajour now creates the `.config` dir if it does not exist on macOS and Linux.
   - This fixes a crash where Ajour coudn't start if the user didn't have a `.config` directory.
 - Fixed a issue where Ajour would crash if CurseForge returned Minecraft addons instead of a World of Warcraft addons.

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -333,8 +333,6 @@ pub fn run() {
 
     let mut settings = Settings::default();
     settings.window.size = config.window_size.unwrap_or((900, 620));
-    // Enforce the usage of dedicated gpu if available.
-    settings.antialiasing = true;
 
     // Sets the Window icon.
     let image = image::load_from_memory_with_format(WINDOW_ICON, ImageFormat::Ico)


### PR DESCRIPTION
Resolves issue where users would load and se Ajour without any text.

## Proposed Changes
Upstream has this issue: https://github.com/hecrj/iced/issues/537
For now we will just remove antialiasing because it's only for triangle primitives.

## Checklist
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
