### PR TITLE
chore: re-added aa due to large memory footprint without

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 ### Fixed
 
-- Fixed a issue where Ajour would start without showing any text.
 - Ajour now creates the `.config` dir if it does not exist on macOS and Linux.
   - This fixes a crash where Ajour coudn't start if the user didn't have a `.config` directory.
 - Fixed a issue where Ajour would crash if CurseForge returned Minecraft addons instead of a World of Warcraft addons.

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -333,6 +333,7 @@ pub fn run() {
 
     let mut settings = Settings::default();
     settings.window.size = config.window_size.unwrap_or((900, 620));
+    settings.antialiasing = true;
 
     // Sets the Window icon.
     let image = image::load_from_memory_with_format(WINDOW_ICON, ImageFormat::Ico)


### PR DESCRIPTION
## Proposed Changes
Apparently removing AA will curse a huge footprint in memory and strange glitches. We will leave it on for now.
