### PR TITLE
OpenGL build

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,6 +17,10 @@ jobs:
         with:
           command: check
           args: --all
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all --no-default-features --features opengl
 
   test:
     name: Test Suite
@@ -32,6 +36,10 @@ jobs:
         with:
           command: test
           args: --workspace
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --no-default-features --features opengl
 
   fmt:
     name: Rustfmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 ## [0.3.5] - 2020-10-01
 ### Packaging
 - Updated Ajour icon.
+- Added an alternative build that uses OpenGL. This will allow Ajour to be used by the widest possible audience, and resolve issues where users couldn't use Ajour with older / certain GPU configurations. An alternative download link will be provided to users wanting to try this build over the default.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_glue"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
+
+[[package]]
 name = "android_log-sys"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +363,15 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cgl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "chrono"
@@ -1236,6 +1251,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glam"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,6 +1284,103 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "glow"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a86c1086850aab0767f4ef01df03c7bdb1cefe18af303571ec144115b733b7b"
+dependencies = [
+ "gl_generator",
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glow_glyph"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5815747c30e2d42c8f75cbd17829d8de16ce78bcc6dee357d69ee0cb3211e206"
+dependencies = [
+ "bytemuck",
+ "glow",
+ "glyph_brush",
+ "log",
+]
+
+[[package]]
+name = "glutin"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a9666c8fd9afd008f6559e2468c35e11aad1d110d525bb3b354e4138ec0e20f"
+dependencies = [
+ "android_glue",
+ "cgl",
+ "cocoa",
+ "core-foundation 0.7.0",
+ "core-graphics",
+ "glutin_egl_sys",
+ "glutin_emscripten_sys",
+ "glutin_gles2_sys",
+ "glutin_glx_sys",
+ "glutin_wgl_sys",
+ "lazy_static",
+ "libloading 0.5.2",
+ "log",
+ "objc",
+ "osmesa-sys",
+ "parking_lot",
+ "wayland-client",
+ "winapi 0.3.9",
+ "winit",
+]
+
+[[package]]
+name = "glutin_egl_sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2abb6aa55523480c4adc5a56bbaa249992e2dddb2fc63dc96e04a3355364c211"
+dependencies = [
+ "gl_generator",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "glutin_emscripten_sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80de4146df76e8a6c32b03007bc764ff3249dcaeb4f675d68a06caf1bac363f1"
+
+[[package]]
+name = "glutin_gles2_sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094e708b730a7c8a1954f4f8a31880af00eb8a1c5b5bf85d28a0a3c6d69103"
+dependencies = [
+ "gl_generator",
+ "objc",
+]
+
+[[package]]
+name = "glutin_glx_sys"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e393c8fc02b807459410429150e9c4faffdb312d59b8c038566173c81991351"
+dependencies = [
+ "gl_generator",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5951a1569dbab865c6f2a863efafff193a93caf05538d193e9e3816d21696"
+dependencies = [
+ "gl_generator",
 ]
 
 [[package]]
@@ -1345,6 +1468,8 @@ source = "git+https://github.com/hecrj/iced.git?rev=fb015a85d22a7c4632bd251127a8
 dependencies = [
  "iced_core",
  "iced_futures",
+ "iced_glow",
+ "iced_glutin",
  "iced_web",
  "iced_wgpu",
  "iced_winit",
@@ -1364,6 +1489,32 @@ dependencies = [
  "futures",
  "log",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "iced_glow"
+version = "0.1.0"
+source = "git+https://github.com/hecrj/iced.git?rev=fb015a85d22a7c4632bd251127a89259bfd0c346#fb015a85d22a7c4632bd251127a89259bfd0c346"
+dependencies = [
+ "bytemuck",
+ "euclid",
+ "glow",
+ "glow_glyph",
+ "glyph_brush",
+ "iced_graphics",
+ "iced_native",
+ "log",
+]
+
+[[package]]
+name = "iced_glutin"
+version = "0.1.0"
+source = "git+https://github.com/hecrj/iced.git?rev=fb015a85d22a7c4632bd251127a89259bfd0c346#fb015a85d22a7c4632bd251127a89259bfd0c346"
+dependencies = [
+ "glutin",
+ "iced_graphics",
+ "iced_native",
+ "iced_winit",
 ]
 
 [[package]]
@@ -1567,6 +1718,12 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kv-log-macro"
@@ -2057,6 +2214,15 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+]
+
+[[package]]
+name = "osmesa-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
+dependencies = [
+ "shared_library",
 ]
 
 [[package]]
@@ -2725,6 +2891,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,6 +2911,12 @@ name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "slotmap"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c46a3482db8f247956e464d783693ece164ca056e6e67563ee5505bdb86452cd"
 
 [[package]]
 name = "sluice"
@@ -3359,6 +3541,7 @@ dependencies = [
 name = "widgets"
 version = "0.1.0"
 dependencies = [
+ "iced_glow",
  "iced_graphics",
  "iced_native",
  "iced_wgpu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,16 @@ keywords = ["addon-manager", "wow", "world-of-warcraft", "addon"]
 categories = ["graphics", "gui", "games"]
 edition = "2018"
 
+[features]
+default = ["wgpu"]
+wgpu = ["widgets/wgpu", "iced/wgpu", "iced/default_system_font"]
+opengl = ["widgets/opengl", "iced/glow", "iced/glow_default_system_font"]
+
 [dependencies]
 ajour-core = { path = "crates/core", features=['gui'] }
 widgets = { path = "crates/widgets" }
 
-iced = { git = "https://github.com/hecrj/iced.git", features = ["debug"], rev = "fb015a85d22a7c4632bd251127a89259bfd0c346" }
+iced = { git = "https://github.com/hecrj/iced.git", default-features = false, features = ["debug"], rev = "fb015a85d22a7c4632bd251127a89259bfd0c346" }
 iced_futures = { git = "https://github.com/hecrj/iced.git", features = ["async-std"], rev = "fb015a85d22a7c4632bd251127a89259bfd0c346" }
 iced_native = { git = "https://github.com/hecrj/iced.git", rev = "fb015a85d22a7c4632bd251127a89259bfd0c346" }
 async-std = "1.6.2"

--- a/crates/widgets/Cargo.toml
+++ b/crates/widgets/Cargo.toml
@@ -4,8 +4,13 @@ version = "0.1.0"
 authors = ["tarkah <admin@tarkah.dev>"]
 edition = "2018"
 
+[features]
+wgpu = ["iced_wgpu"]
+opengl = ["iced_glow"]
 
 [dependencies]
 iced_native = { git="https://github.com/hecrj/iced", rev="fb015a85d22a7c4632bd251127a89259bfd0c346" }
-iced_wgpu = { git="https://github.com/hecrj/iced", rev="fb015a85d22a7c4632bd251127a89259bfd0c346" }
 iced_graphics = { git="https://github.com/hecrj/iced", rev="fb015a85d22a7c4632bd251127a89259bfd0c346" }
+
+iced_wgpu = { git="https://github.com/hecrj/iced", rev="fb015a85d22a7c4632bd251127a89259bfd0c346", optional = true }
+iced_glow = { git="https://github.com/hecrj/iced", rev="fb015a85d22a7c4632bd251127a89259bfd0c346", optional = true }

--- a/crates/widgets/src/lib.rs
+++ b/crates/widgets/src/lib.rs
@@ -1,7 +1,7 @@
-#[cfg(feature="wgpu")]
+#[cfg(feature = "wgpu")]
 use iced_wgpu::Renderer;
 
-#[cfg(feature="opengl")]
+#[cfg(feature = "opengl")]
 use iced_glow::Renderer;
 
 mod renderer;

--- a/crates/widgets/src/lib.rs
+++ b/crates/widgets/src/lib.rs
@@ -1,4 +1,8 @@
+#[cfg(feature="wgpu")]
 use iced_wgpu::Renderer;
+
+#[cfg(feature="opengl")]
+use iced_glow::Renderer;
 
 mod renderer;
 mod widget;

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -333,7 +333,11 @@ pub fn run() {
 
     let mut settings = Settings::default();
     settings.window.size = config.window_size.unwrap_or((900, 620));
-    settings.antialiasing = true;
+
+    #[cfg(feature = "wgpu")]
+    {
+        settings.antialiasing = true;
+    }
 
     // Sets the Window icon.
     let image = image::load_from_memory_with_format(WINDOW_ICON, ImageFormat::Ico)


### PR DESCRIPTION
Resolves hopefully #163 & #153 and other issues people have where Ajour crashes on startup.

This can be built using the following command: `cargo build --no-default-features  --features opengl`

## Proposed Changes
  - provide an alternative build that uses OpenGL instead of wgpu (DirectX12, Vulkan, Metal). This should be a much wider supported build, at the cost of rendering performance.

## Checklist

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
