### PR TITLE
feat: abstracted all categories option for a cleaner interface

### DIFF
--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -46,11 +46,37 @@ pub struct Catalog {
 pub struct CatalogAddon {
     pub id: u32,
     pub name: String,
-    pub categories: Vec<String>,
+    pub categories: Vec<CatalogCategory>,
     pub summary: String,
     pub number_of_downloads: u64,
     pub source: Source,
     pub flavors: Vec<Flavor>,
+}
+
+#[serde(transparent)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct CatalogCategory {
+    pub name: String,
+}
+
+impl CatalogCategory {
+    pub fn all_option() -> Self {
+        CatalogCategory {
+            name: String::from("All Categories"),
+        }
+    }
+}
+
+impl std::fmt::Display for CatalogCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+impl Default for CatalogCategory {
+    fn default() -> Self {
+        CatalogCategory::all_option()
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -46,37 +46,11 @@ pub struct Catalog {
 pub struct CatalogAddon {
     pub id: u32,
     pub name: String,
-    pub categories: Vec<CatalogCategory>,
+    pub categories: Vec<String>,
     pub summary: String,
     pub number_of_downloads: u64,
     pub source: Source,
     pub flavors: Vec<Flavor>,
-}
-
-#[serde(transparent)]
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct CatalogCategory {
-    pub name: String,
-}
-
-impl CatalogCategory {
-    pub fn all_option() -> Self {
-        CatalogCategory {
-            name: String::from("All Categories"),
-        }
-    }
-}
-
-impl std::fmt::Display for CatalogCategory {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.name)
-    }
-}
-
-impl Default for CatalogCategory {
-    fn default() -> Self {
-        CatalogCategory::all_option()
-    }
 }
 
 #[cfg(test)]

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -6,7 +6,7 @@ use crate::cli::Opts;
 use crate::VERSION;
 use ajour_core::{
     addon::{Addon, ReleaseChannel},
-    catalog::{Catalog, CatalogAddon, CatalogCategory},
+    catalog::{Catalog, CatalogAddon},
     config::{load_config, ColumnConfigV2, Config, Flavor},
     error::ClientError,
     fs::PersistentData,
@@ -364,10 +364,6 @@ impl Application for Ajour {
                     .style(style::CatalogQueryInput(color_palette));
 
                     let catalog_query: Element<Interaction> = catalog_query.into();
-
-                    // Insert the default option as the first option (placeholder)
-                    let mut categories = categories.to_owned();
-                    categories.insert(0, Default::default());
 
                     let category_picklist = PickList::new(
                         &mut self.catalog_query_state.categories_state,
@@ -921,6 +917,27 @@ impl From<CatalogAddon> for CatalogRow {
             btn_state: Default::default(),
             addon,
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum CatalogCategory {
+    All,
+    Choice(String),
+}
+
+impl std::fmt::Display for CatalogCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CatalogCategory::All => write!(f, "{}", "All Categories"),
+            CatalogCategory::Choice(name) => write!(f, "{}", name),
+        }
+    }
+}
+
+impl Default for CatalogCategory {
+    fn default() -> Self {
+        CatalogCategory::All
     }
 }
 

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -6,7 +6,7 @@ use {
     ajour_core::{
         addon::{Addon, AddonState},
         backup::{backup_folders, latest_backup, BackupFolder},
-        catalog::get_catalog,
+        catalog::{get_catalog, CatalogCategory},
         config::{load_config, ColumnConfig, ColumnConfigV2, Flavor},
         curse_api::latest_stable_addon_from_id,
         fs::{delete_addons, install_addon, PersistentData},
@@ -1003,10 +1003,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
         Message::Interaction(Interaction::CatalogCategorySelected(category)) => {
             log::debug!("Interaction::CatalogCategorySelected({})", &category);
 
-            ajour.catalog_query_state.category = match category.as_str() {
-                "All categories" => None,
-                _ => Some(category),
-            };
+            ajour.catalog_query_state.category = category;
 
             query_and_sort_catalog(ajour);
         }
@@ -1272,10 +1269,10 @@ fn query_and_sort_catalog(ajour: &mut Ajour) {
         catalog_rows = catalog_rows
             .into_iter()
             .filter(|a| {
-                if let Some(category) = &category {
-                    a.addon.categories.iter().any(|c| c == category)
-                } else {
+                if category == &CatalogCategory::all_option() {
                     true
+                } else {
+                    a.addon.categories.iter().any(|c| c == category)
                 }
             })
             .enumerate()


### PR DESCRIPTION
## Proposed Changes
  - Abstracts away the very implicit api of injecting the All Categories into the category dropdown.
  - The new interface implements both `Default` and a static function for retrieving the `all_option()` and it resembles the interface of the result size dropdown to generate a more cohesive codebase.
