### PR TITLE
feat: better wow path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 ## [Unreleased]
 
+### Added
+- Logic for falling back to root World of Warcraft directory if a sub-folder was chosen
+
 ## [0.3.5] - 2020-10-01
 ### Packaging
 - Updated Ajour icon.

--- a/crates/core/src/utility.rs
+++ b/crates/core/src/utility.rs
@@ -77,8 +77,6 @@ mod tests {
 
     #[test]
     fn test_wow_path_resolution() {
-        // Tests known result
-
         let classic_addon_path =
             PathBuf::from(r"/Applications/World of Warcraft/_classic_/Interface/Addons");
         let retail_addon_path =

--- a/crates/core/src/utility.rs
+++ b/crates/core/src/utility.rs
@@ -2,6 +2,8 @@ use crate::{network::request_async, Result};
 use isahc::prelude::*;
 use regex::Regex;
 use serde::Deserialize;
+use std::ffi::OsStr;
+use std::path::PathBuf;
 
 /// Takes a `&str` and strips any non-digit.
 /// This is used to unify and compare addon versions:
@@ -38,5 +40,73 @@ pub async fn needs_update(current_version: &str) -> Result<Option<String>> {
         Ok(Some(release.tag_name))
     } else {
         Ok(None)
+    }
+}
+
+/// Logic to help pick the right World of Warcraft folder. We want the root folder.
+pub fn wow_path_resolution(path: Option<PathBuf>) -> Option<PathBuf> {
+    if let Some(path) = path {
+        // If chosen path has any of the known Wow folders, we have the right one.
+        let known_folders = ["_retail_", "_classic_"];
+        for folder in known_folders.iter() {
+            if path.join(folder).exists() {
+                return Some(path);
+            }
+        }
+
+        // Iterate ancestors. If we find any of the known folders we can guess the root.
+        for ancestor in path.as_path().ancestors() {
+            if let Some(file_name) = ancestor.file_name() {
+                if file_name == OsStr::new("_retail_") || file_name == OsStr::new("_classic_") {
+                    return ancestor.parent().map(|p| p.to_path_buf());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wow_path() {
+        // Tests known result
+
+        let classic_addon_path =
+            PathBuf::from(r"/Applications/World of Warcraft/_classic_/Interface/Addons");
+        let retail_addon_path =
+            PathBuf::from(r"/Applications/World of Warcraft/_retail_/Interface/Addons");
+        let retail_interface_path =
+            PathBuf::from(r"/Applications/World of Warcraft/_retail_/Interface");
+        let classic_interface_path =
+            PathBuf::from(r"/Applications/World of Warcraft/_classic_/Interface");
+        let classic_alternate_path = PathBuf::from(r"/Applications/Wow/_classic_");
+
+        let root_alternate_path = PathBuf::from(r"/Applications/Wow");
+        let root_path = PathBuf::from(r"/Applications/World of Warcraft");
+
+        assert_eq!(
+            root_path.eq(&wow_path_resolution(Some(classic_addon_path)).unwrap()),
+            true
+        );
+        assert_eq!(
+            root_path.eq(&wow_path_resolution(Some(retail_addon_path)).unwrap()),
+            true
+        );
+        assert_eq!(
+            root_path.eq(&wow_path_resolution(Some(retail_interface_path)).unwrap()),
+            true
+        );
+        assert_eq!(
+            root_path.eq(&wow_path_resolution(Some(classic_interface_path)).unwrap()),
+            true
+        );
+        assert_eq!(
+            root_alternate_path.eq(&wow_path_resolution(Some(classic_alternate_path)).unwrap()),
+            true
+        );
     }
 }

--- a/crates/core/src/utility.rs
+++ b/crates/core/src/utility.rs
@@ -72,7 +72,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_wow_path() {
+    fn test_wow_path_resolution() {
         // Tests known result
 
         let classic_addon_path =

--- a/crates/core/src/utility.rs
+++ b/crates/core/src/utility.rs
@@ -46,8 +46,10 @@ pub async fn needs_update(current_version: &str) -> Result<Option<String>> {
 /// Logic to help pick the right World of Warcraft folder. We want the root folder.
 pub fn wow_path_resolution(path: Option<PathBuf>) -> Option<PathBuf> {
     if let Some(path) = path {
+        // Known folders in World of Warcraft dir
+        let known_folders = ["_retail_", "_classic_", "_ptr_"];
+
         // If chosen path has any of the known Wow folders, we have the right one.
-        let known_folders = ["_retail_", "_classic_"];
         for folder in known_folders.iter() {
             if path.join(folder).exists() {
                 return Some(path);
@@ -57,8 +59,10 @@ pub fn wow_path_resolution(path: Option<PathBuf>) -> Option<PathBuf> {
         // Iterate ancestors. If we find any of the known folders we can guess the root.
         for ancestor in path.as_path().ancestors() {
             if let Some(file_name) = ancestor.file_name() {
-                if file_name == OsStr::new("_retail_") || file_name == OsStr::new("_classic_") {
-                    return ancestor.parent().map(|p| p.to_path_buf());
+                for folder in known_folders.iter() {
+                    if file_name == OsStr::new(folder) {
+                        return ancestor.parent().map(|p| p.to_path_buf());
+                    }
                 }
             }
         }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -7,6 +7,7 @@ use {
         fs::{delete_addons, install_addon, PersistentData},
         network::download_addon,
         parse::{read_addon_directory, update_addon_fingerprint, FingerprintCollection},
+        utility::wow_path_resolution,
         Result,
     },
     async_std::sync::{Arc, Mutex},
@@ -239,8 +240,10 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 Message::None,
             ));
         }
-        Message::UpdateWowDirectory(path) => {
-            log::debug!("Message::UpdateWowDirectory({:?})", &path);
+        Message::UpdateWowDirectory(chosen_path) => {
+            log::debug!("Message::UpdateWowDirectory(Chosen({:?}))", &chosen_path);
+            let path = wow_path_resolution(chosen_path);
+            log::debug!("Message::UpdateWowDirectory(Resolution({:?}))", &path);
 
             // Clear addons.
             ajour.addons = HashMap::new();


### PR DESCRIPTION
Resolves #194 

## Proposed Changes
Better logic for picking the World of Warcraft directory:
- When a user selects the root dir i'll check if any known folder (`_retail_`, or `_classic_`) is there, if yes use that dir.
- When a user selects a sub folder of the root dir (eg. `World of Warcraft/_retail_/Interface`) i'll look at the ancestors and if I find a known sub-folder to the root dir (`_retail_`, or `_classic_`) i'll use the parent of that sub-folder.

To test this run `cargo test test_wow_path_resolution --all`.
Currently only tested on macOS, will test on Windows tomorrow.

## Checklist

- [x] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
