### PR TITLE
Proposal : Add localization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@
 
 # Editor config
 .vscode/
+
+# Translation files exclusions
+/i18n/pot
+/i18n/mo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 ## [Unreleased]
 
+## [0.3.5] - 2020-10-01
 ### Packaging
 - Updated Ajour icon.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,6 @@ dependencies = [
  "iced_native",
  "image",
  "isahc",
- "locale_config 0.2.3",
  "log",
  "log-panics",
  "native-dialog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,16 +55,20 @@ dependencies = [
  "chrono",
  "embed-resource",
  "fern",
+ "i18n-embed",
  "iced",
  "iced_futures",
  "iced_native",
  "image",
  "isahc",
+ "locale_config 0.2.3",
  "log",
  "log-panics",
  "native-dialog",
  "opener",
+ "rust-embed",
  "timeago",
+ "tr",
  "widgets",
 ]
 
@@ -412,6 +416,15 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
  "bitflags",
 ]
@@ -784,6 +797,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +920,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-crate"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057a1d48e8ff33649ee2d7c510b79ecf1f8a52b684d446a72de600ad7e2823b6"
+dependencies = [
+ "toml",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +945,15 @@ name = "float-ord"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bad48618fdb549078c333a7a8528acb57af271d0433bdecd523eb620628364e"
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ad0989667548f06ccd0e306ed56b61bd4d35458d54df5ec7587c0e8ed5e94"
+dependencies = [
+ "unic-langid",
+]
 
 [[package]]
 name = "fnv"
@@ -1080,6 +1175,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "gettext"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ebb594e753d5997e4be036e5a8cf048ab9414352870fb45c779557bbc9ba971"
+dependencies = [
+ "byteorder",
+ "encoding",
+]
+
+[[package]]
+name = "gettext-rs"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df454a42d8a718280c78666efe0707c120873736961ae91ead898f17ac66ce7c"
+dependencies = [
+ "gettext-sys",
+ "locale_config 0.2.3",
+]
+
+[[package]]
+name = "gettext-sys"
+version = "0.19.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e034c4ba5bb796730a6cc5eb0d654c16885006a7c3d6c6603581ed809434f153"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "gfx-auxil"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,7 +1225,7 @@ dependencies = [
  "gfx-hal",
  "libloading 0.6.2",
  "log",
- "parking_lot",
+ "parking_lot 0.10.2",
  "range-alloc",
  "raw-window-handle",
  "smallvec",
@@ -1157,7 +1281,7 @@ dependencies = [
  "log",
  "metal",
  "objc",
- "parking_lot",
+ "parking_lot 0.10.2",
  "range-alloc",
  "raw-window-handle",
  "smallvec",
@@ -1336,6 +1460,52 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "i18n-config"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6d8f6c9a922e3346c6db230bb139e360bf14b3e13e611abd771776c78e8250"
+dependencies = [
+ "log",
+ "serde",
+ "serde_derive",
+ "thiserror",
+ "toml",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c5adf8bd243aa286eff83a6989b5c8e39081af8f1cf4de07c1b7cd514937373"
+dependencies = [
+ "fluent-langneg",
+ "gettext",
+ "i18n-embed-impl",
+ "lazy_static",
+ "locale_config 0.3.0",
+ "log",
+ "parking_lot 0.11.0",
+ "rust-embed",
+ "thiserror",
+ "tr",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed-impl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4dbd191f5a08e7f8dd3331c0a43340508a31e07b3c562151722e6eb65f9f86"
+dependencies = [
+ "find-crate",
+ "i18n-config",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn",
 ]
 
 [[package]]
@@ -1652,10 +1822,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
+name = "locale_config"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ac19ebe45489e5d53b4346d8b90bb3dd03275c5fdf2ce22a982516d86b535c"
+dependencies = [
+ "lazy_static",
+ "regex",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "locale_config"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d2c35b16f4483f6c26f0e4e9550717a2f6575bcd6f12a53ff0c490a94a6934"
+dependencies = [
+ "lazy_static",
+ "objc",
+ "objc-foundation",
+ "regex",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
 dependencies = [
  "scopeguard",
 ]
@@ -2080,8 +2283,19 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
- "lock_api",
- "parking_lot_core",
+ "lock_api 0.3.4",
+ "parking_lot_core 0.7.2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+dependencies = [
+ "instant",
+ "lock_api 0.4.1",
+ "parking_lot_core 0.8.0",
 ]
 
 [[package]]
@@ -2091,7 +2305,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if",
+ "cloudabi 0.1.0",
+ "instant",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -2422,7 +2651,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
- "cloudabi",
+ "cloudabi 0.0.3",
  "fuchsia-cprng",
  "libc",
  "rand_core 0.4.2",
@@ -2543,6 +2772,38 @@ dependencies = [
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rust-embed"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213acf1bc5a6dfcd70b62db1e9a7d06325c0e73439c312fcb8599d456d9686ee"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7903c2cf599db8f310b392332f38367ca4acc84420fa1aee3536299f433c10d5"
+dependencies = [
+ "quote 1.0.7",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97655158074ccb2d2cfb1ccb4c956ef0f4054e43a2c1e71146d4991e6961e105"
+dependencies = [
+ "walkdir",
 ]
 
 [[package]]
@@ -2839,7 +3100,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd0a4829a5c591dc24a944a736d6b1e4053e51339a79fd5d4702c4c999a9c45e"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.4",
 ]
 
 [[package]]
@@ -2932,6 +3193,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29738eedb4388d9ea620eeab9384884fc3f06f586a2eddb56bedc5885126c7c1"
+
+[[package]]
 name = "tinyvec"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2944,6 +3211,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tr"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d374e7e01e645085c3940425b9a755a66835089ca4e239e4de2fc74d68300cf"
+dependencies = [
+ "gettext",
+ "gettext-rs",
+ "lazy_static",
 ]
 
 [[package]]
@@ -3001,6 +3279,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
 dependencies = [
  "rand 0.7.3",
+]
+
+[[package]]
+name = "unic-langid"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73328fcd730a030bdb19ddf23e192187a6b01cd98be6d3140622a89129459ce5"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a4a8eeaf0494862c1404c95ec2f4c33a2acff5076f64314b465e3ddae1b934d"
+dependencies = [
+ "serde",
+ "tinystr",
 ]
 
 [[package]]
@@ -3273,7 +3570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5dece29f3cd403aabf4056595eabe4b9af56b8bfae12445f097cf8666a41829"
 dependencies = [
  "arrayvec",
- "parking_lot",
+ "parking_lot 0.10.2",
  "raw-window-handle",
  "smallvec",
  "wgpu-core",
@@ -3300,7 +3597,7 @@ dependencies = [
  "gfx-hal",
  "gfx-memory",
  "log",
- "parking_lot",
+ "parking_lot 0.10.2",
  "peek-poke",
  "smallvec",
  "vec_map",
@@ -3317,7 +3614,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "objc",
- "parking_lot",
+ "parking_lot 0.10.2",
  "raw-window-handle",
  "wgpu-core",
  "wgpu-types",
@@ -3442,7 +3739,7 @@ dependencies = [
  "ndk-glue",
  "ndk-sys",
  "objc",
- "parking_lot",
+ "parking_lot 0.10.2",
  "percent-encoding",
  "raw-window-handle",
  "smithay-client-toolkit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ dependencies = [
  "log",
  "objc",
  "osmesa-sys",
- "parking_lot",
+ "parking_lot 0.10.2",
  "wayland-client",
  "winapi 0.3.9",
  "winit",
@@ -3898,7 +3898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5dece29f3cd403aabf4056595eabe4b9af56b8bfae12445f097cf8666a41829"
 dependencies = [
  "arrayvec 0.5.1",
- "parking_lot",
+ "parking_lot 0.10.2",
  "raw-window-handle",
  "smallvec",
  "wgpu-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,8 @@ dependencies = [
  "iced_native",
  "image",
  "isahc",
+ "lazy_static",
+ "locale_config 0.2.3",
  "log",
  "log-panics",
  "native-dialog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ tr = "0.1.3"
 rust-embed = "5.6.0"
 structopt = "0.3"
 num-format = "0.4.0"
+lazy_static = "*"
+locale_config = "*"
 
 [build-dependencies]
 embed-resource = "1.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ log = "0.4"
 fern = "0.6"
 timeago = "0.2.1"
 log-panics = { version = "2.0", features=['with-backtrace'] }
+i18n-embed = { version = "0.8", features = ["gettext-system", "desktop-requester"]}
+tr = "0.1.3"
+rust-embed = "5.6.0"
 
 [build-dependencies]
 embed-resource = "1.3.3"

--- a/TRANSLATE.md
+++ b/TRANSLATE.md
@@ -1,0 +1,47 @@
+# Adding a translation
+In order to add a translation, there are several steps to take, which are described in this document.
+
+## Pre-requisites
+The following tools are necessary to add a new translation and parse the codebase for strings to translate.
+
+1. Cargo-i18n (Simplifies the creation of the translation files)
+```
+cargo install cargo-i18n
+```
+
+2. xtr (This is used by Cargo-i18n to automatically extract strings to translate from the code.)
+```
+cargo install xtr
+```
+
+## Add a new language in i18n.toml
+In order to add a new translation, a new target language must be defined in the localization configuration file.
+
+In `i18n.toml`, add a new language code (for a list of ISO 639-1 compatible language codes, see https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+
+**For example, if I wanted to add a russian translation to the already present french translation**
+```
+[gettext]
+# (Required) The languages that the software will be translated into.
+target_languages = ["fr","ru"]
+```
+
+## Create the translation file
+To create the translation file (a `.po` file) that will contain your new translations, you simply run the cargo i18n tool from the root of the project.
+
+`cargo i18n`
+
+After this, a new folder with your language code will have been created in `/i18n` with a file named `ajour.po` that contains all the translations to make.
+
+## Testing your translations.
+In order to test your translations, you need to pack all the translation files in a binary format (a `.mo` file) that then gets embedded in the binary. In order to do that, after translating all the strings, you run the cargo-i18n tool again, then rebuild and run the app.
+
+```
+cargo i18n
+
+cargo build
+
+cargo run
+```
+
+**Important: This translation system takes into account the locale of your system (Windows, Mac or Linux) to make a decision on which strings to display in the application. So if your system is not in the proper locale, you will not see your translations.**

--- a/TRANSLATE.md
+++ b/TRANSLATE.md
@@ -1,5 +1,5 @@
-# Adding a translation
-In order to add a translation, there are several steps to take, which are described in this document.
+# Adding a new target language
+In order to add a new target language for translation, there are several steps to take, which are described in this document.
 
 ## Pre-requisites
 The following tools are necessary to add a new translation and parse the codebase for strings to translate.
@@ -45,3 +45,10 @@ cargo run
 ```
 
 **Important: This translation system takes into account the locale of your system (Windows, Mac or Linux) to make a decision on which strings to display in the application. So if your system is not in the proper locale, you will not see your translations.**
+
+# Translate a string in the code.
+In order for a string to be picked up by the `cargo i18n` command and therefore added to a translation `.po` file, it needs to be wrapped with the tr macro, like so:
+
+```
+tr!("Some text to translate")
+```

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -22,6 +22,8 @@ pub struct Config {
 
     pub theme: Option<String>,
 
+    pub language: Option<String>,
+
     #[serde(default)]
     pub column_config: ColumnConfig,
 

--- a/i18n.toml
+++ b/i18n.toml
@@ -1,0 +1,13 @@
+# (Required) The language identifier of the language used in the
+# source code for gettext system, and the primary fallback language
+# (for which all strings must be present) when using the fluent
+# system.
+fallback_language = "en"
+
+[gettext]
+# (Required) The languages that the software will be translated into.
+target_languages = ["fr"]
+
+# (Required) Path to the output directory, relative to `i18n.toml` of the crate
+# being localized.
+output_dir = "i18n"

--- a/i18n/po/fr/ajour.po
+++ b/i18n/po/fr/ajour.po
@@ -1,0 +1,220 @@
+# French translations for ajour package.
+# Copyright (C) 2020 THE ajour'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the ajour package.
+# Jeremie CARPENTIER-ROY <jeremie.carpentier.roy@gmail.com>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: ajour 0.3.5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-10-06 13:51+0000\n"
+"PO-Revision-Date: 2020-10-05 15:32-0400\n"
+"Last-Translator: Jeremie Carpentier-Roy <jeremie.carpentier.roy@gmail.com>\n"
+"Language-Team: French\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. Title for the World of Warcraft directory selection.
+#: src/gui/element.rs:39
+msgid "World of Warcraft directory"
+msgstr "Répertoire d'installation"
+
+#: src/gui/element.rs:47 src/gui/element.rs:158
+msgid "Select Directory"
+msgstr "Sélectionner"
+
+#. Directory text, written next to directory button to let the user
+#. know what has been selected.
+#: src/gui/element.rs:58 src/gui/element.rs:166
+msgid "No directory is set"
+msgstr "Aucun répertoire n'est sélectionné"
+
+#. Title for the theme pick list.
+#: src/gui/element.rs:80
+msgid "Theme"
+msgstr "Thème"
+
+#: src/gui/element.rs:107
+msgid "UI Scale"
+msgstr "Échelle de l'interface"
+
+#. Title for the Backup section.
+#: src/gui/element.rs:152
+msgid "Backup"
+msgstr "Répertoire de sauvegarde"
+
+#: src/gui/element.rs:197
+msgid "Backup Now"
+msgstr "Sauvegarder maintenant"
+
+#: src/gui/element.rs:208
+msgid "Backing up..."
+msgstr "Sauvegarde en cours..."
+
+#: src/gui/element.rs:215
+msgid "Never"
+msgstr "Jamais"
+
+#: src/gui/element.rs:217
+msgid "Last backup: {}"
+msgstr "Dernière sauvegarde : {}"
+
+#: src/gui/element.rs:234
+msgid "Back up your AddOns and WTF folder to the chosen directory"
+msgstr "Sauvegarder les répertoires AddOns et WTF à l'emplacement choisi"
+
+#. Title for the Columns section.
+#: src/gui/element.rs:250
+msgid "Columns"
+msgstr "Colonnes"
+
+#: src/gui/element.rs:609
+msgid "Update"
+msgstr "Mettre à jour"
+
+#: src/gui/element.rs:625
+msgid "Downloading"
+msgstr "Téléchargement"
+
+#: src/gui/element.rs:633
+msgid "Unpacking"
+msgstr "Extraction"
+
+#: src/gui/element.rs:640
+msgid "Hashing"
+msgstr "Hachage"
+
+#: src/gui/element.rs:647
+msgid "Ignored"
+msgstr "Ignoré"
+
+#: src/gui/element.rs:678
+msgid "No description for addon."
+msgstr "Aucune description"
+
+#: src/gui/element.rs:684
+msgid "Summary"
+msgstr "Résumé"
+
+#: src/gui/element.rs:687
+msgid "Author(s)"
+msgstr "Auteur(s)"
+
+#: src/gui/element.rs:703
+msgid "has no avaiable release"
+msgstr "Aucune version publiée disponible"
+
+#: src/gui/element.rs:711
+msgid "Remote release channel"
+msgstr "Canal de publication distant"
+
+#: src/gui/element.rs:726
+msgid "Website"
+msgstr "Site web"
+
+#: src/gui/element.rs:738
+msgid "Force update"
+msgstr "Forcer la mise à jour"
+
+#: src/gui/element.rs:752
+msgid "Unignore"
+msgstr "Dé-ignorer"
+
+#: src/gui/element.rs:754
+msgid "Ignore"
+msgstr "Ignorer"
+
+#: src/gui/element.rs:771
+msgid "Delete"
+msgstr "Supprimer"
+
+#: src/gui/element.rs:924
+msgid "Update All"
+msgstr "Tout mettre à jour"
+
+#: src/gui/element.rs:930
+msgid "Refresh"
+msgstr "Rafraîchir"
+
+#: src/gui/element.rs:967
+msgid "Retail"
+msgstr ""
+
+#: src/gui/element.rs:974
+msgid "Classic"
+msgstr ""
+
+#: src/gui/element.rs:1013
+msgid "{} {} addons loaded"
+msgstr "{} addons {} chargés"
+
+#: src/gui/element.rs:1042
+msgid "New Ajour version available {} -> {}"
+msgstr "Nouvelle version d'Ajour disponible {} -> {}"
+
+#: src/gui/element.rs:1058
+msgid "Settings"
+msgstr "Paramètres"
+
+#: src/gui/element.rs:1087
+msgid "Download"
+msgstr "Télécharger"
+
+#. Status messages.
+#: src/gui/mod.rs:289
+msgid "Welcome to Ajour!"
+msgstr "Bienvenue dans Ajour!"
+
+#: src/gui/mod.rs:290
+msgid ""
+"To get started, go to Settings and select your World of Warcraft directory."
+msgstr ""
+"Pour commencer, aller dans les Paramètres et sélectionner le répertoire "
+"d'installation de World of Warcraft."
+
+#: src/gui/mod.rs:291
+msgid "Woops!"
+msgstr "Oups!"
+
+#: src/gui/mod.rs:292
+msgid "Loading.."
+msgstr "Téléchargement.."
+
+#: src/gui/mod.rs:293
+msgid "Currently parsing addons."
+msgstr "Parcours des addons..."
+
+#: src/gui/mod.rs:305
+msgid "You have no {} addons"
+msgstr "Vous n'avez pas d'addons {}"
+
+#: src/gui/mod.rs:378
+msgid "Addon"
+msgstr ""
+
+#: src/gui/mod.rs:379
+msgid "Local"
+msgstr ""
+
+#: src/gui/mod.rs:380
+msgid "Remote"
+msgstr "Distant"
+
+#: src/gui/mod.rs:381
+msgid "Status"
+msgstr "Statut"
+
+#: src/gui/mod.rs:382
+msgid "Channel"
+msgstr "Canal"
+
+#: src/gui/mod.rs:383
+msgid "Author"
+msgstr "Auteur"
+
+#: src/gui/mod.rs:384
+msgid "Game Version"
+msgstr "Version du jeu"

--- a/i18n/po/fr/ajour.po
+++ b/i18n/po/fr/ajour.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ajour 0.3.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-06 13:51+0000\n"
+"POT-Creation-Date: 2020-10-06 21:05+0000\n"
 "PO-Revision-Date: 2020-10-05 15:32-0400\n"
 "Last-Translator: Jeremie Carpentier-Roy <jeremie.carpentier.roy@gmail.com>\n"
 "Language-Team: French\n"
@@ -18,203 +18,219 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. Title for the World of Warcraft directory selection.
-#: src/gui/element.rs:39
+#: src/gui/element.rs:42
 msgid "World of Warcraft directory"
-msgstr "Répertoire d'installation"
+msgstr "Répertoire d'installation de World of Warcraft"
 
-#: src/gui/element.rs:47 src/gui/element.rs:158
+#: src/gui/element.rs:46 src/gui/element.rs:152
 msgid "Select Directory"
 msgstr "Sélectionner"
 
 #. Directory text, written next to directory button to let the user
 #. know what has been selected.
-#: src/gui/element.rs:58 src/gui/element.rs:166
+#: src/gui/element.rs:60 src/gui/element.rs:167
 msgid "No directory is set"
 msgstr "Aucun répertoire n'est sélectionné"
 
 #. Title for the theme pick list.
-#: src/gui/element.rs:80
+#: src/gui/element.rs:82
 msgid "Theme"
 msgstr "Thème"
 
-#: src/gui/element.rs:107
+#: src/gui/element.rs:106
 msgid "UI Scale"
 msgstr "Échelle de l'interface"
 
 #. Title for the Backup section.
-#: src/gui/element.rs:152
+#: src/gui/element.rs:147
 msgid "Backup"
 msgstr "Répertoire de sauvegarde"
 
-#: src/gui/element.rs:197
+#: src/gui/element.rs:196
 msgid "Backup Now"
-msgstr "Sauvegarder maintenant"
+msgstr "Sauvegarder"
 
-#: src/gui/element.rs:208
+#: src/gui/element.rs:214
 msgid "Backing up..."
 msgstr "Sauvegarde en cours..."
 
-#: src/gui/element.rs:215
+#: src/gui/element.rs:221
 msgid "Never"
 msgstr "Jamais"
 
-#: src/gui/element.rs:217
+#: src/gui/element.rs:223
 msgid "Last backup: {}"
 msgstr "Dernière sauvegarde : {}"
 
-#: src/gui/element.rs:234
+#: src/gui/element.rs:241
 msgid "Back up your AddOns and WTF folder to the chosen directory"
 msgstr "Sauvegarder les répertoires AddOns et WTF à l'emplacement choisi"
 
 #. Title for the Columns section.
-#: src/gui/element.rs:250
+#: src/gui/element.rs:258
 msgid "Columns"
 msgstr "Colonnes"
 
-#: src/gui/element.rs:609
+#: src/gui/element.rs:626
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: src/gui/element.rs:625
+#: src/gui/element.rs:642
 msgid "Downloading"
 msgstr "Téléchargement"
 
-#: src/gui/element.rs:633
+#: src/gui/element.rs:650
 msgid "Unpacking"
 msgstr "Extraction"
 
-#: src/gui/element.rs:640
+#: src/gui/element.rs:657
 msgid "Hashing"
 msgstr "Hachage"
 
-#: src/gui/element.rs:647
+#: src/gui/element.rs:664
 msgid "Ignored"
 msgstr "Ignoré"
 
-#: src/gui/element.rs:678
+#: src/gui/element.rs:695
 msgid "No description for addon."
 msgstr "Aucune description"
 
-#: src/gui/element.rs:684
+#: src/gui/element.rs:700
 msgid "Summary"
 msgstr "Résumé"
 
-#: src/gui/element.rs:687
+#: src/gui/element.rs:703
 msgid "Author(s)"
 msgstr "Auteur(s)"
 
-#: src/gui/element.rs:703
+#: src/gui/element.rs:719
 msgid "has no avaiable release"
 msgstr "Aucune version publiée disponible"
 
-#: src/gui/element.rs:711
+#: src/gui/element.rs:727
 msgid "Remote release channel"
 msgstr "Canal de publication distant"
 
-#: src/gui/element.rs:726
+#: src/gui/element.rs:742
 msgid "Website"
 msgstr "Site web"
 
-#: src/gui/element.rs:738
+#: src/gui/element.rs:754
 msgid "Force update"
 msgstr "Forcer la mise à jour"
 
-#: src/gui/element.rs:752
+#: src/gui/element.rs:768
 msgid "Unignore"
 msgstr "Dé-ignorer"
 
-#: src/gui/element.rs:754
+#: src/gui/element.rs:770
 msgid "Ignore"
 msgstr "Ignorer"
 
-#: src/gui/element.rs:771
+#: src/gui/element.rs:787
 msgid "Delete"
 msgstr "Supprimer"
 
-#: src/gui/element.rs:924
+#: src/gui/element.rs:940
 msgid "Update All"
 msgstr "Tout mettre à jour"
 
-#: src/gui/element.rs:930
+#: src/gui/element.rs:946
 msgid "Refresh"
 msgstr "Rafraîchir"
 
-#: src/gui/element.rs:967
+#: src/gui/element.rs:986 src/gui/mod.rs:1186
 msgid "Retail"
 msgstr ""
 
-#: src/gui/element.rs:974
+#: src/gui/element.rs:993 src/gui/mod.rs:1187
 msgid "Classic"
 msgstr ""
 
-#: src/gui/element.rs:1013
+#: src/gui/element.rs:1032
 msgid "{} {} addons loaded"
 msgstr "{} addons {} chargés"
 
-#: src/gui/element.rs:1042
+#: src/gui/element.rs:1096
+msgid "My Addons"
+msgstr "Mes addons"
+
+#: src/gui/element.rs:1102
+msgid "Catalog"
+msgstr "Catalogue"
+
+#: src/gui/element.rs:1143
 msgid "New Ajour version available {} -> {}"
 msgstr "Nouvelle version d'Ajour disponible {} -> {}"
 
-#: src/gui/element.rs:1058
+#: src/gui/element.rs:1159
 msgid "Settings"
 msgstr "Paramètres"
 
-#: src/gui/element.rs:1087
+#: src/gui/element.rs:1178
 msgid "Download"
 msgstr "Télécharger"
 
-#. Status messages.
-#: src/gui/mod.rs:289
+#: src/gui/mod.rs:384
+msgid "Search for an addon..."
+msgstr "Chercher un addon"
+
+#: src/gui/mod.rs:582
 msgid "Welcome to Ajour!"
 msgstr "Bienvenue dans Ajour!"
 
-#: src/gui/mod.rs:290
-msgid ""
-"To get started, go to Settings and select your World of Warcraft directory."
-msgstr ""
-"Pour commencer, aller dans les Paramètres et sélectionner le répertoire "
-"d'installation de World of Warcraft."
+#: src/gui/mod.rs:583
+msgid "Please select your World of Warcraft directory"
+msgstr "Sélectionner le répertoire d'installation de World of Warcraft"
 
-#: src/gui/mod.rs:291
+#: src/gui/mod.rs:591
 msgid "Woops!"
 msgstr "Oups!"
 
-#: src/gui/mod.rs:292
+#: src/gui/mod.rs:592
+msgid "You have no {} addons."
+msgstr "Vous n'avez pas d'addons {}"
+
+#: src/gui/mod.rs:604 src/gui/mod.rs:610
 msgid "Loading.."
 msgstr "Téléchargement.."
 
-#: src/gui/mod.rs:293
+#: src/gui/mod.rs:605
 msgid "Currently parsing addons."
-msgstr "Parcours des addons..."
+msgstr "Traitement des addons..."
 
-#: src/gui/mod.rs:305
-msgid "You have no {} addons"
-msgstr "Vous n'avez pas d'addons {}"
+#: src/gui/mod.rs:611
+msgid "Currently loading addon catalog."
+msgstr "Chargement du catalogue d'addons..."
 
-#: src/gui/mod.rs:378
+#: src/gui/mod.rs:687
 msgid "Addon"
 msgstr ""
 
-#: src/gui/mod.rs:379
+#: src/gui/mod.rs:688
 msgid "Local"
 msgstr ""
 
-#: src/gui/mod.rs:380
+#: src/gui/mod.rs:689
 msgid "Remote"
 msgstr "Distant"
 
-#: src/gui/mod.rs:381
+#: src/gui/mod.rs:690
 msgid "Status"
 msgstr "Statut"
 
-#: src/gui/mod.rs:382
+#: src/gui/mod.rs:691
 msgid "Channel"
 msgstr "Canal"
 
-#: src/gui/mod.rs:383
+#: src/gui/mod.rs:692
 msgid "Author"
 msgstr "Auteur"
 
-#: src/gui/mod.rs:384
+#: src/gui/mod.rs:693
 msgid "Game Version"
 msgstr "Version du jeu"
+
+#: src/gui/mod.rs:1184
+msgid "Both Flavors"
+msgstr ""

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -4,7 +4,7 @@ use {
     super::{
         style, AjourMode, AjourState, BackupState, CatalogColumnKey, CatalogColumnState,
         CatalogRow, ColumnKey, ColumnSettings, ColumnState, DirectoryType, Interaction, Message,
-        ReleaseChannel, ScaleState, SortDirection, ThemeState,
+        ReleaseChannel, ScaleState, SortDirection, ThemeState, LanguageState
     },
     crate::VERSION,
     ajour_core::{
@@ -32,6 +32,7 @@ pub fn settings_container<'a, 'b>(
     color_palette: ColorPalette,
     directory_button_state: &'a mut button::State,
     config: &Config,
+    language_state : &'a mut LanguageState,
     theme_state: &'a mut ThemeState,
     scale_state: &'a mut ScaleState,
     backup_state: &'a mut BackupState,
@@ -77,6 +78,29 @@ pub fn settings_container<'a, 'b>(
         .push(directory_button.map(Message::Interaction))
         .push(Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0)))
         .push(directory_data_text_container);
+
+    // Title for the language pick list
+    let language_info_text = Text::new(tr!("Language")).size(14);
+    let language_info_row = Row::new().push(language_info_text);
+
+    let language_codes = language_state
+        .languages
+        .iter()
+        .cloned()
+        .map(|name|name)
+        .collect::<Vec<_>>();
+    let language_pick_list = PickList::new(
+        &mut language_state.pick_list_state,
+        language_codes,
+        Some(language_state.current_language_name.clone()),
+        Message::LanguageSelected,
+    )
+    .text_size(14)
+    .width(Length::Units(100))
+    .style(style::PickList(color_palette));
+
+    // Data row for language pick list
+    let language_data_row = Row::new().push(language_pick_list);
 
     // Title for the theme pick list.
     let theme_info_text = Text::new(tr!("Theme")).size(14);
@@ -373,7 +397,12 @@ pub fn settings_container<'a, 'b>(
         .push(Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING)))
         .push(theme_info_row)
         .push(Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING)))
-        .push(theme_data_row);
+        .push(theme_data_row)
+        .push(Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING)))
+        .push(language_info_row)
+        .push(Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING)))
+        .push(language_data_row);
+
 
     let left_spacer = Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0));
     let right_spacer = Space::new(Length::Units(DEFAULT_PADDING + 5), Length::Units(0));

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -16,6 +16,7 @@ use {
         button, scrollable, Align, Button, Checkbox, Column, Container, Element,
         HorizontalAlignment, Length, PickList, Row, Scrollable, Space, Text, VerticalAlignment,
     },
+    tr::tr,
     widgets::{header, Header},
 };
 
@@ -35,7 +36,7 @@ pub fn settings_container<'a, 'b>(
     column_config: &'b [(ColumnKey, Length, bool)],
 ) -> Container<'a, Message> {
     // Title for the World of Warcraft directory selection.
-    let directory_info_text = Text::new("World of Warcraft directory").size(14);
+    let directory_info_text = Text::new(tr!("World of Warcraft directory")).size(14);
     let directory_info_row = Row::new()
         .push(directory_info_text)
         .padding(DEFAULT_PADDING);
@@ -43,7 +44,7 @@ pub fn settings_container<'a, 'b>(
     // Directory button for World of Warcraft directory selection.
     let directory_button: Element<Interaction> = Button::new(
         directory_button_state,
-        Text::new("Select Directory").size(DEFAULT_FONT_SIZE),
+        Text::new(tr!("Select Directory")).size(DEFAULT_FONT_SIZE),
     )
     .style(style::DefaultBoxedButton(color_palette))
     .on_press(Interaction::OpenDirectory(DirectoryType::Wow))
@@ -54,12 +55,13 @@ pub fn settings_container<'a, 'b>(
 
     // Directory text, written next to directory button to let the user
     // know what has been selected..
+    let directory_text = tr!("No directory is set");
     let path_str = config
         .wow
         .directory
         .as_ref()
         .and_then(|p| p.to_str())
-        .unwrap_or("No directory is set");
+        .unwrap_or(&directory_text);
     let directory_data_text = Text::new(path_str)
         .size(14)
         .vertical_alignment(VerticalAlignment::Center);
@@ -75,7 +77,7 @@ pub fn settings_container<'a, 'b>(
         .push(directory_data_text_container);
 
     // Title for the theme pick list.
-    let theme_info_text = Text::new("Theme").size(14);
+    let theme_info_text = Text::new(tr!("Theme")).size(14);
     let theme_info_row = Row::new().push(theme_info_text).padding(DEFAULT_PADDING);
 
     // We add some margin left to adjust to the rest of the content.
@@ -102,7 +104,7 @@ pub fn settings_container<'a, 'b>(
 
     // Scale buttons for application scale factoring.
     let (scale_title_row, scale_buttons_row) = {
-        let scale_title = Text::new("UI Scale").size(DEFAULT_FONT_SIZE);
+        let scale_title = Text::new(tr!("UI Scale")).size(DEFAULT_FONT_SIZE);
         let scale_title_row = Row::new().push(scale_title).padding(DEFAULT_PADDING);
 
         let scale_down_button: Element<Interaction> = Button::new(
@@ -147,13 +149,13 @@ pub fn settings_container<'a, 'b>(
 
     let (backup_title_row, backup_directory_row, backup_now_row) = {
         // Title for the Backup section.
-        let backup_title_text = Text::new("Backup").size(DEFAULT_FONT_SIZE);
+        let backup_title_text = Text::new(tr!("Backup")).size(DEFAULT_FONT_SIZE);
         let backup_title_row = Row::new().push(backup_title_text).padding(DEFAULT_PADDING);
 
         // Directory button for Backup directory selection.
         let directory_button: Element<Interaction> = Button::new(
             &mut backup_state.directory_btn_state,
-            Text::new("Select Directory").size(DEFAULT_FONT_SIZE),
+            Text::new(tr!("Select Directory")).size(DEFAULT_FONT_SIZE),
         )
         .style(style::DefaultBoxedButton(color_palette))
         .on_press(Interaction::OpenDirectory(DirectoryType::Backup))
@@ -161,11 +163,12 @@ pub fn settings_container<'a, 'b>(
 
         // Directory text, written next to directory button to let the user
         // know what has been selected.
+        let directory_text = tr!("No directory is set");
         let path_str = config
             .backup_directory
             .as_ref()
             .and_then(|p| p.to_str())
-            .unwrap_or("No directory is set");
+            .unwrap_or(&directory_text);
         let directory_data_text = Text::new(path_str)
             .size(DEFAULT_FONT_SIZE)
             .vertical_alignment(VerticalAlignment::Center);
@@ -191,7 +194,7 @@ pub fn settings_container<'a, 'b>(
         if config.backup_directory.is_some() {
             let mut backup_button = Button::new(
                 &mut backup_state.backup_now_btn_state,
-                Text::new("Backup Now").size(DEFAULT_FONT_SIZE),
+                Text::new(tr!("Backup Now")).size(DEFAULT_FONT_SIZE),
             )
             .style(style::DefaultBoxedButton(color_palette));
 
@@ -202,16 +205,16 @@ pub fn settings_container<'a, 'b>(
             }
 
             let backup_status_text = if backup_state.backing_up {
-                Text::new("Backing up...")
+                Text::new(tr!("Backing up..."))
                     .size(DEFAULT_FONT_SIZE)
                     .vertical_alignment(VerticalAlignment::Center)
             } else {
                 let as_of = backup_state
                     .last_backup
                     .map(|d| d.format("%Y-%m-%d %H:%M:%S").to_string())
-                    .unwrap_or_else(|| "Never".to_string());
+                    .unwrap_or_else(|| tr!("Never").to_string());
 
-                Text::new(&format!("Last backup: {}", as_of))
+                Text::new(&tr!("Last backup: {}", as_of))
                     .size(DEFAULT_FONT_SIZE)
                     .vertical_alignment(VerticalAlignment::Center)
             };
@@ -228,7 +231,7 @@ pub fn settings_container<'a, 'b>(
                 .push(backup_status_text_container);
         } else {
             let backup_status_text =
-                Text::new("Back up your AddOns and WTF folder to the chosen directory")
+                Text::new(tr!("Back up your AddOns and WTF folder to the chosen directory"))
                     .size(DEFAULT_FONT_SIZE)
                     .vertical_alignment(VerticalAlignment::Center);
 
@@ -244,7 +247,7 @@ pub fn settings_container<'a, 'b>(
 
     let (columns_title_row, columns_scrollable) = {
         // Title for the Columns section.
-        let columns_title_text = Text::new("Columns").size(DEFAULT_FONT_SIZE);
+        let columns_title_text = Text::new(tr!("Columns")).size(DEFAULT_FONT_SIZE);
         let columns_title_row = Row::new().push(columns_title_text).padding(DEFAULT_PADDING);
 
         // Scrollable for column selections
@@ -603,7 +606,7 @@ pub fn addon_data_cell<'a, 'b>(
                 let id = addon.id.clone();
                 let update_button: Element<Interaction> = Button::new(
                     &mut addon.update_btn_state,
-                    Text::new("Update")
+                    Text::new(tr!("Update"))
                         .horizontal_alignment(HorizontalAlignment::Center)
                         .size(DEFAULT_FONT_SIZE),
                 )
@@ -619,7 +622,7 @@ pub fn addon_data_cell<'a, 'b>(
                     .style(style::AddonRowDefaultTextContainer(color_palette))
             }
             AddonState::Downloading => {
-                Container::new(Text::new("Downloading").size(DEFAULT_FONT_SIZE))
+                Container::new(Text::new(tr!("Downloading")).size(DEFAULT_FONT_SIZE))
                     .height(default_height)
                     .width(*width)
                     .center_y()
@@ -627,21 +630,21 @@ pub fn addon_data_cell<'a, 'b>(
                     .padding(5)
                     .style(style::AddonRowSecondaryTextContainer(color_palette))
             }
-            AddonState::Unpacking => Container::new(Text::new("Unpacking").size(DEFAULT_FONT_SIZE))
+            AddonState::Unpacking => Container::new(Text::new(tr!("Unpacking")).size(DEFAULT_FONT_SIZE))
                 .height(default_height)
                 .width(*width)
                 .center_y()
                 .center_x()
                 .padding(5)
                 .style(style::AddonRowSecondaryTextContainer(color_palette)),
-            AddonState::Fingerprint => Container::new(Text::new("Hashing").size(DEFAULT_FONT_SIZE))
+            AddonState::Fingerprint => Container::new(Text::new(tr!("Hashing")).size(DEFAULT_FONT_SIZE))
                 .height(default_height)
                 .width(*width)
                 .center_y()
                 .center_x()
                 .padding(5)
                 .style(style::AddonRowSecondaryTextContainer(color_palette)),
-            AddonState::Ignored => Container::new(Text::new("Ignored").size(DEFAULT_FONT_SIZE))
+            AddonState::Ignored => Container::new(Text::new(tr!("Ignored")).size(DEFAULT_FONT_SIZE))
                 .height(default_height)
                 .width(*width)
                 .center_y()
@@ -672,16 +675,16 @@ pub fn addon_data_cell<'a, 'b>(
         let notes = addon
             .notes
             .clone()
-            .unwrap_or_else(|| "No description for addon.".to_string());
+            .unwrap_or_else(|| tr!("No description for addon.").to_string());
         let author = addon.author.clone().unwrap_or_else(|| "-".to_string());
         let left_spacer = Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0));
         let right_spacer = Space::new(Length::Units(DEFAULT_PADDING + 5), Length::Units(0));
         let space = Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING * 2));
         let bottom_space = Space::new(Length::Units(0), Length::Units(4));
-        let notes_title_text = Text::new("Summary").size(DEFAULT_FONT_SIZE);
+        let notes_title_text = Text::new(tr!("Summary")).size(DEFAULT_FONT_SIZE);
         let notes_text = Text::new(notes).size(DEFAULT_FONT_SIZE);
         let author_text = Text::new(author).size(DEFAULT_FONT_SIZE);
-        let author_title_text = Text::new("Author(s)").size(DEFAULT_FONT_SIZE);
+        let author_title_text = Text::new(tr!("Author(s)")).size(DEFAULT_FONT_SIZE);
         let author_title_container =
             Container::new(author_title_text).style(style::DefaultTextContainer(color_palette));
         let notes_title_container =
@@ -697,7 +700,7 @@ pub fn addon_data_cell<'a, 'b>(
                 "".to_string()
             }
         } else {
-            "has no avaiable release".to_string()
+            tr!("has no avaiable release").to_string()
         };
         let release_date_text = Text::new(release_date_text).size(DEFAULT_FONT_SIZE);
         let release_date_text_container = Container::new(release_date_text)
@@ -705,7 +708,7 @@ pub fn addon_data_cell<'a, 'b>(
             .padding(5)
             .style(style::SecondaryTextContainer(color_palette));
 
-        let release_channel_title = Text::new("Remote release channel").size(DEFAULT_FONT_SIZE);
+        let release_channel_title = Text::new(tr!("Remote release channel")).size(DEFAULT_FONT_SIZE);
         let release_channel_title_container =
             Container::new(release_channel_title).style(style::DefaultTextContainer(color_palette));
         let release_channel_list = PickList::new(
@@ -720,7 +723,7 @@ pub fn addon_data_cell<'a, 'b>(
 
         let mut website_button = Button::new(
             &mut addon.website_btn_state,
-            Text::new("Website").size(DEFAULT_FONT_SIZE),
+            Text::new(tr!("Website")).size(DEFAULT_FONT_SIZE),
         )
         .style(style::DefaultBoxedButton(color_palette));
 
@@ -732,7 +735,7 @@ pub fn addon_data_cell<'a, 'b>(
 
         let mut force_download_button = Button::new(
             &mut addon.force_btn_state,
-            Text::new("Force update").size(DEFAULT_FONT_SIZE),
+            Text::new(tr!("Force update")).size(DEFAULT_FONT_SIZE),
         )
         .style(style::DefaultBoxedButton(color_palette));
 
@@ -746,9 +749,9 @@ pub fn addon_data_cell<'a, 'b>(
 
         let is_ignored = addon.state == AddonState::Ignored;
         let ignore_button_text = if is_ignored {
-            Text::new("Unignore").size(DEFAULT_FONT_SIZE)
+            Text::new(tr!("Unignore")).size(DEFAULT_FONT_SIZE)
         } else {
-            Text::new("Ignore").size(DEFAULT_FONT_SIZE)
+            Text::new(tr!("Ignore")).size(DEFAULT_FONT_SIZE)
         };
 
         let mut ignore_button = Button::new(&mut addon.ignore_btn_state, ignore_button_text)
@@ -765,7 +768,7 @@ pub fn addon_data_cell<'a, 'b>(
 
         let delete_button: Element<Interaction> = Button::new(
             &mut addon.delete_btn_state,
-            Text::new("Delete").size(DEFAULT_FONT_SIZE),
+            Text::new(tr!("Delete")).size(DEFAULT_FONT_SIZE),
         )
         .on_press(Interaction::Delete(addon.id.clone()))
         .style(style::DeleteBoxedButton(color_palette))
@@ -918,13 +921,13 @@ pub fn menu_container<'a>(
 
     let mut update_all_button = Button::new(
         update_all_button_state,
-        Text::new("Update All").size(DEFAULT_FONT_SIZE),
+        Text::new(tr!("Update All")).size(DEFAULT_FONT_SIZE),
     )
     .style(style::DefaultBoxedButton(color_palette));
 
     let mut refresh_button = Button::new(
         refresh_button_state,
-        Text::new("Refresh").size(DEFAULT_FONT_SIZE),
+        Text::new(tr!("Refresh")).size(DEFAULT_FONT_SIZE),
     )
     .style(style::DefaultBoxedButton(color_palette));
 
@@ -961,14 +964,14 @@ pub fn menu_container<'a>(
 
     let mut retail_button = Button::new(
         retail_btn_state,
-        Text::new("Retail").size(DEFAULT_FONT_SIZE),
+        Text::new(tr!("Retail")).size(DEFAULT_FONT_SIZE),
     )
     .style(style::SegmentedDisabledButton(color_palette))
     .on_press(Interaction::FlavorSelected(Flavor::Retail));
 
     let mut classic_button = Button::new(
         classic_btn_state,
-        Text::new("Classic").size(DEFAULT_FONT_SIZE),
+        Text::new(tr!("Classic")).size(DEFAULT_FONT_SIZE),
     )
     .style(style::SegmentedDisabledButton(color_palette))
     .on_press(Interaction::FlavorSelected(Flavor::Classic));
@@ -1006,7 +1009,7 @@ pub fn menu_container<'a>(
         .count();
 
     let status_text = match state {
-        AjourState::Idle => Text::new(format!(
+        AjourState::Idle => Text::new(tr!(
             "{} {} addons loaded",
             parent_addons_count,
             config.wow.flavor.to_string()
@@ -1036,7 +1039,7 @@ pub fn menu_container<'a>(
         .style(style::StatusErrorTextContainer(color_palette));
 
     let version_text = Text::new(if let Some(new_version) = needs_update {
-        format!("New Ajour version available {} -> {}", VERSION, new_version)
+        tr!("New Ajour version available {} -> {}", VERSION, new_version)
     } else {
         VERSION.to_owned()
     })
@@ -1052,7 +1055,7 @@ pub fn menu_container<'a>(
 
     let settings_button: Element<Interaction> = Button::new(
         settings_button_state,
-        Text::new("Settings")
+        Text::new(tr!("Settings"))
             .horizontal_alignment(HorizontalAlignment::Center)
             .size(DEFAULT_FONT_SIZE),
     )
@@ -1081,7 +1084,7 @@ pub fn menu_container<'a>(
     if needs_update.is_some() {
         let mut new_release_button = Button::new(
             new_release_button_state,
-            Text::new("Download").size(DEFAULT_FONT_SIZE),
+            Text::new(tr!("Download")).size(DEFAULT_FONT_SIZE),
         )
         .style(style::SecondaryButton(color_palette));
 

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -3,8 +3,8 @@
 use {
     super::{
         style, AjourMode, AjourState, BackupState, CatalogColumnKey, CatalogColumnState,
-        CatalogRow, ColumnKey, ColumnSettings, ColumnState, DirectoryType, Interaction, Message,
-        ReleaseChannel, ScaleState, SortDirection, ThemeState, LanguageState
+        CatalogRow, ColumnKey, ColumnSettings, ColumnState, DirectoryType, Interaction,
+        LanguageState, Message, ReleaseChannel, ScaleState, SortDirection, ThemeState,
     },
     crate::VERSION,
     ajour_core::{
@@ -18,10 +18,22 @@ use {
         button, scrollable, Align, Button, Checkbox, Column, Container, Element,
         HorizontalAlignment, Length, PickList, Row, Scrollable, Space, Text, VerticalAlignment,
     },
-    tr::tr,
     num_format::{Locale, ToFormattedString},
+    tr::tr,
     widgets::{header, Header},
+    i18n_embed::{DesktopLanguageRequester, gettext::{
+        gettext_language_loader,
+    },unic_langid},
+    rust_embed::RustEmbed,
 };
+
+#[derive(RustEmbed)]
+// path to the compiled localization resources,
+// as determined by i18n.toml settings
+#[folder = "i18n/mo"]
+struct Translations;
+
+
 
 // Default values used on multiple elements.
 pub static DEFAULT_FONT_SIZE: u16 = 14;
@@ -32,15 +44,15 @@ pub fn settings_container<'a, 'b>(
     color_palette: ColorPalette,
     directory_button_state: &'a mut button::State,
     config: &Config,
-    language_state : &'a mut LanguageState,
+    language_state: &'a mut LanguageState,
     theme_state: &'a mut ThemeState,
     scale_state: &'a mut ScaleState,
     backup_state: &'a mut BackupState,
     column_settings: &'a mut ColumnSettings,
     column_config: &'b [(ColumnKey, Length, bool)],
 ) -> Container<'a, Message> {
+
     // Title for the World of Warcraft directory selection.
-    log::debug!("thread locale : {}",locale_config::Locale::current());
     let directory_info_text = Text::new(tr!("World of Warcraft directory")).size(14);
 
     // Directory button for World of Warcraft directory selection.
@@ -88,7 +100,7 @@ pub fn settings_container<'a, 'b>(
         .languages
         .iter()
         .cloned()
-        .map(|name|name)
+        .map(|name| name)
         .collect::<Vec<_>>();
     let language_pick_list = PickList::new(
         &mut language_state.pick_list_state,
@@ -262,10 +274,11 @@ pub fn settings_container<'a, 'b>(
                 .push(Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0)))
                 .push(backup_status_text_container);
         } else {
-            let backup_status_text =
-                Text::new(tr!("Back up your AddOns and WTF folder to the chosen directory"))
-                    .size(DEFAULT_FONT_SIZE)
-                    .vertical_alignment(VerticalAlignment::Center);
+            let backup_status_text = Text::new(tr!(
+                "Back up your AddOns and WTF folder to the chosen directory"
+            ))
+            .size(DEFAULT_FONT_SIZE)
+            .vertical_alignment(VerticalAlignment::Center);
 
             let backup_status_text_container = Container::new(backup_status_text)
                 .height(Length::Units(25))
@@ -403,7 +416,6 @@ pub fn settings_container<'a, 'b>(
         .push(language_info_row)
         .push(Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING)))
         .push(language_data_row);
-
 
     let left_spacer = Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0));
     let right_spacer = Space::new(Length::Units(DEFAULT_PADDING + 5), Length::Units(0));
@@ -677,27 +689,33 @@ pub fn addon_data_cell<'a, 'b>(
                     .padding(5)
                     .style(style::AddonRowSecondaryTextContainer(color_palette))
             }
-            AddonState::Unpacking => Container::new(Text::new(tr!("Unpacking")).size(DEFAULT_FONT_SIZE))
-                .height(default_height)
-                .width(*width)
-                .center_y()
-                .center_x()
-                .padding(5)
-                .style(style::AddonRowSecondaryTextContainer(color_palette)),
-            AddonState::Fingerprint => Container::new(Text::new(tr!("Hashing")).size(DEFAULT_FONT_SIZE))
-                .height(default_height)
-                .width(*width)
-                .center_y()
-                .center_x()
-                .padding(5)
-                .style(style::AddonRowSecondaryTextContainer(color_palette)),
-            AddonState::Ignored => Container::new(Text::new(tr!("Ignored")).size(DEFAULT_FONT_SIZE))
-                .height(default_height)
-                .width(*width)
-                .center_y()
-                .center_x()
-                .padding(5)
-                .style(style::AddonRowSecondaryTextContainer(color_palette)),
+            AddonState::Unpacking => {
+                Container::new(Text::new(tr!("Unpacking")).size(DEFAULT_FONT_SIZE))
+                    .height(default_height)
+                    .width(*width)
+                    .center_y()
+                    .center_x()
+                    .padding(5)
+                    .style(style::AddonRowSecondaryTextContainer(color_palette))
+            }
+            AddonState::Fingerprint => {
+                Container::new(Text::new(tr!("Hashing")).size(DEFAULT_FONT_SIZE))
+                    .height(default_height)
+                    .width(*width)
+                    .center_y()
+                    .center_x()
+                    .padding(5)
+                    .style(style::AddonRowSecondaryTextContainer(color_palette))
+            }
+            AddonState::Ignored => {
+                Container::new(Text::new(tr!("Ignored")).size(DEFAULT_FONT_SIZE))
+                    .height(default_height)
+                    .width(*width)
+                    .center_y()
+                    .center_x()
+                    .padding(5)
+                    .style(style::AddonRowSecondaryTextContainer(color_palette))
+            }
         };
 
         row_containers.push((idx, update_button_container));
@@ -754,7 +772,8 @@ pub fn addon_data_cell<'a, 'b>(
             .padding(5)
             .style(style::SecondaryTextContainer(color_palette));
 
-        let release_channel_title = Text::new(tr!("Remote release channel")).size(DEFAULT_FONT_SIZE);
+        let release_channel_title =
+            Text::new(tr!("Remote release channel")).size(DEFAULT_FONT_SIZE);
         let release_channel_title_container =
             Container::new(release_channel_title).style(style::DefaultTextContainer(color_palette));
         let release_channel_list = PickList::new(

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -40,6 +40,7 @@ pub fn settings_container<'a, 'b>(
     column_config: &'b [(ColumnKey, Length, bool)],
 ) -> Container<'a, Message> {
     // Title for the World of Warcraft directory selection.
+    log::debug!("thread locale : {}",locale_config::Locale::current());
     let directory_info_text = Text::new(tr!("World of Warcraft directory")).size(14);
 
     // Directory button for World of Warcraft directory selection.

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -1093,13 +1093,13 @@ pub fn menu_container<'a>(
 
     let mut addons_mode_button = Button::new(
         addon_mode_button_state,
-        Text::new("My Addons").size(DEFAULT_FONT_SIZE),
+        Text::new(tr!("My Addons")).size(DEFAULT_FONT_SIZE),
     )
     .style(style::SegmentedDisabledButton(color_palette));
 
     let mut catalog_mode_button = Button::new(
         catalog_mode_btn_state,
-        Text::new("Catalog").size(DEFAULT_FONT_SIZE),
+        Text::new(tr!("Catalog")).size(DEFAULT_FONT_SIZE),
     )
     .style(style::SegmentedDisabledButton(color_palette));
 
@@ -1235,7 +1235,7 @@ pub fn status_container<'a>(
 
     if let (_, Some(btn_state)) = (AjourState::Welcome, onboarding_directory_btn_state) {
         let onboarding_button_title_container =
-            Container::new(Text::new("Select Directory").size(DEFAULT_FONT_SIZE))
+            Container::new(Text::new(tr!("Select Directory")).size(DEFAULT_FONT_SIZE))
                 .width(Length::Units(100))
                 .center_x()
                 .align_x(Align::Center);

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -103,6 +103,7 @@ pub enum Message {
     Parse(Result<Config>),
     ParsedAddons((Flavor, Result<Vec<Addon>>)),
     UpdateFingerprint((Flavor, String, Result<()>)),
+    LanguageSelected(String),
     ThemeSelected(String),
     ReleaseChannelSelected(ReleaseChannel),
     ThemesLoaded(Vec<Theme>),
@@ -132,6 +133,7 @@ pub struct Ajour {
     mode: AjourMode,
     update_all_btn_state: button::State,
     header_state: HeaderState,
+    language_state: LanguageState,
     theme_state: ThemeState,
     fingerprint_collection: Arc<Mutex<Option<FingerprintCollection>>>,
     retail_btn_state: button::State,
@@ -171,6 +173,7 @@ impl Default for Ajour {
             mode: AjourMode::MyAddons,
             update_all_btn_state: Default::default(),
             header_state: Default::default(),
+            language_state: Default::default(),
             theme_state: Default::default(),
             fingerprint_collection: Arc::new(Mutex::new(None)),
             retail_btn_state: Default::default(),
@@ -279,6 +282,7 @@ impl Application for Ajour {
                 color_palette,
                 &mut self.directory_btn_state,
                 &cloned_config,
+                &mut self.language_state,
                 &mut self.theme_state,
                 &mut self.scale_state,
                 &mut self.backup_state,
@@ -1225,6 +1229,26 @@ pub struct ThemeState {
     themes: Vec<(String, Theme)>,
     current_theme_name: String,
     pick_list_state: pick_list::State<String>,
+}
+
+pub struct LanguageState {
+    languages: Vec<String>,
+    current_language_name: String,
+    pick_list_state: pick_list::State<String>,
+}
+
+impl Default for LanguageState{
+    fn default() -> Self {
+        let mut languages = vec![];
+        languages.push("EN".to_string());
+        languages.push("FR".to_string());
+
+        LanguageState {
+            languages,
+            current_language_name: "EN".to_string(),
+            pick_list_state: Default::default(),
+        }
+    }
 }
 
 impl Default for ThemeState {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -381,7 +381,7 @@ impl Application for Ajour {
 
                     let catalog_query = TextInput::new(
                         &mut self.catalog_search_state.query_state,
-                        "Search for an addon...",
+                        &tr!("Search for an addon..."),
                         query,
                         Interaction::CatalogQuery,
                     )
@@ -579,8 +579,8 @@ impl Application for Ajour {
         let container: Option<Container<Message>> = match self.state {
             AjourState::Welcome => Some(element::status_container(
                 color_palette,
-                tr!("Welcome to Ajour!"),
-                tr!("Please select your World of Warcraft directory"),
+                &tr!("Welcome to Ajour!"),
+                &tr!("Please select your World of Warcraft directory"),
                 Some(&mut self.onboarding_directory_btn_state),
             )),
             AjourState::Idle => match self.mode {
@@ -588,7 +588,7 @@ impl Application for Ajour {
                     if !has_addons {
                         Some(element::status_container(
                             color_palette,
-                            tr!("Woops!"),
+                            &tr!("Woops!"),
                             &tr!("You have no {} addons.", flavor.to_string().to_lowercase()),
                             None,
                         ))
@@ -601,14 +601,14 @@ impl Application for Ajour {
             AjourState::Loading => match self.mode {
                 AjourMode::MyAddons => Some(element::status_container(
                     color_palette,
-                    tr!("Loading.."),
-                    tr!("Currently parsing addons."),
+                    &tr!("Loading.."),
+                    &tr!("Currently parsing addons."),
                     None,
                 )),
                 AjourMode::Catalog => Some(element::status_container(
                     color_palette,
-                    tr!("Loading.."),
-                    tr!("Currently loading addon catalog."),
+                    &tr!("Loading.."),
+                    &tr!("Currently loading addon catalog."),
                     None,
                 )),
             },
@@ -1181,10 +1181,10 @@ impl CatalogFlavor {
 impl std::fmt::Display for CatalogFlavor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
-            CatalogFlavor::All => "Both Flavors",
+            CatalogFlavor::All => tr!("Both Flavors"),
             CatalogFlavor::Choice(flavor) => match flavor {
-                Flavor::Retail => "Retail",
-                Flavor::Classic => "Classic",
+                Flavor::Retail => tr!("Retail"),
+                Flavor::Classic => tr!("Classic"),
             },
         };
         write!(f, "{}", s)

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -32,9 +32,20 @@ use std::path::PathBuf;
 use widgets::header;
 use tr::tr;
 use locale_config::Locale;
+use i18n_embed::{DesktopLanguageRequester, gettext::{
+    gettext_language_loader,
+},unic_langid};  
+use rust_embed::RustEmbed;
 
 use element::{DEFAULT_FONT_SIZE, DEFAULT_PADDING};
 static WINDOW_ICON: &[u8] = include_bytes!("../../resources/windows/ajour.ico");
+
+#[derive(RustEmbed)]
+// path to the compiled localization resources,
+// as determined by i18n.toml settings
+#[folder = "i18n/mo"]
+struct Translations;
+
 
 #[derive(Debug)]
 pub enum AjourState {
@@ -228,12 +239,30 @@ impl Application for Ajour {
     }
 
     fn view(&mut self) -> Element<Message> {
-        // Clone config to be used.
+        // Clone config to be used. 
         // FIXME: This could be done prettier.
         let cloned_config = self.config.clone();
+        
+        // let translations = Translations {};
 
-        let loc = Locale::new(&self.language_state.current_language_name);
-        locale_config::Locale::set_current(loc.unwrap());
+        // // Create the GettextLanguageLoader, pulling in settings from `i18n.toml`
+        // // at compile time using the macro.
+        // let language_loader = gettext_language_loader!();
+
+        // // Use the language requester for the desktop platform (linux, windows, mac).
+        // // There is also a requester available for the web-sys WASM platform called
+        // // WebLanguageRequester, or you can implement your own.
+        // //let requested_languages = DesktopLanguageRequester::requested_languages();
+        
+        // let mut li: unic_langid::LanguageIdentifier = self.language_state.current_language_name.parse()
+        // .expect("Parsing failed.");
+        // let mut requested_languages = Vec::new();
+        // requested_languages.push(li);
+
+        // log::debug!("Requested languages {:?}", requested_languages);
+
+        // let _result = i18n_embed::select(
+        //     &language_loader, &translations, &requested_languages);
 
         // Get color palette of chosen theme.
         let color_palette = self
@@ -1249,7 +1278,7 @@ impl Default for LanguageState{
 
         LanguageState {
             languages,
-            current_language_name: "FR".to_string(),
+            current_language_name: "EN".to_string(),
             pick_list_state: Default::default(),
         }
     }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -31,6 +31,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use widgets::header;
 use tr::tr;
+use locale_config::Locale;
 
 use element::{DEFAULT_FONT_SIZE, DEFAULT_PADDING};
 static WINDOW_ICON: &[u8] = include_bytes!("../../resources/windows/ajour.ico");
@@ -230,6 +231,9 @@ impl Application for Ajour {
         // Clone config to be used.
         // FIXME: This could be done prettier.
         let cloned_config = self.config.clone();
+
+        let loc = Locale::new(&self.language_state.current_language_name);
+        locale_config::Locale::set_current(loc.unwrap());
 
         // Get color palette of chosen theme.
         let color_palette = self
@@ -1245,7 +1249,7 @@ impl Default for LanguageState{
 
         LanguageState {
             languages,
-            current_language_name: "EN".to_string(),
+            current_language_name: "FR".to_string(),
             pick_list_state: Default::default(),
         }
     }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -26,6 +26,7 @@ use isahc::{
 use std::collections::HashMap;
 use std::path::PathBuf;
 use widgets::header;
+use tr::tr;
 
 use image::ImageFormat;
 static WINDOW_ICON: &[u8] = include_bytes!("../../resources/windows/ajour.ico");
@@ -288,15 +289,15 @@ impl Application for Ajour {
         let container: Option<Container<Message>> = match self.state {
             AjourState::Welcome => Some(element::status_container(
                 color_palette,
-                "Welcome to Ajour!",
-                "To get started, go to Settings and select your World of Warcraft directory.",
+                &tr!("Welcome to Ajour!"),
+                &tr!("To get started, go to Settings and select your World of Warcraft directory."),
             )),
             AjourState::Idle => {
                 if !has_addons {
                     Some(element::status_container(
                         color_palette,
-                        "Woops!",
-                        &format!("You have no {} addons.", flavor.to_string().to_lowercase()),
+                        &tr!("Woops!"),
+                        &tr!("You have no {} addons", flavor.to_string().to_lowercase()),
                     ))
                 } else {
                     None
@@ -304,8 +305,8 @@ impl Application for Ajour {
             }
             AjourState::Loading => Some(element::status_container(
                 color_palette,
-                "Loading..",
-                "Currently parsing addons.",
+                &tr!("Loading.."),
+                &tr!("Currently parsing addons."),
             )),
             _ => None,
         };
@@ -369,13 +370,13 @@ impl ColumnKey {
         use ColumnKey::*;
 
         let title = match self {
-            Title => "Addon",
-            LocalVersion => "Local",
-            RemoteVersion => "Remote",
-            Status => "Status",
-            Channel => "Channel",
-            Author => "Author",
-            GameVersion => "Game Version",
+            Title => tr!("Addon"),
+            LocalVersion => tr!("Local"),
+            RemoteVersion => tr!("Remote"),
+            Status => tr!("Status"),
+            Channel => tr!("Channel"),
+            Author => tr!("Author"),
+            GameVersion => tr!("Game Version"),
         };
 
         title.to_string()

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -19,14 +19,25 @@ use {
     async_std::sync::{Arc, Mutex},
     iced::{Command, Length},
     isahc::HttpClient,
+    locale_config::Locale,
     native_dialog::*,
     std::collections::{HashMap, HashSet},
     std::path::{Path, PathBuf},
+    std::ops::Deref,
     widgets::header::ResizeEvent,
-    locale_config::Locale,
+    i18n_embed::{DesktopLanguageRequester, gettext::{
+        gettext_language_loader
+    },unic_langid},
+    rust_embed::RustEmbed,
 };
 
-pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Message>> {    
+#[derive(RustEmbed)]
+// path to the compiled localization resources,
+// as determined by i18n.toml settings
+#[folder = "i18n/mo"]
+struct Translations;
+
+pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Message>> {
     match message {
         Message::Parse(Ok(config)) => {
             log::debug!("Message::Parse");
@@ -768,6 +779,27 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
 
             ajour.config.language = Some(language_name);
             let _ = ajour.config.save();
+
+            // let translations = Translations {};
+
+            // // Create the GettextLanguageLoader, pulling in settings from `i18n.toml`
+            // // at compile time using the macro.
+            // let language_loader = gettext_language_loader!();
+        
+            // // Use the language requester for the desktop platform (linux, windows, mac).
+            // // There is also a requester available for the web-sys WASM platform called
+            // // WebLanguageRequester, or you can implement your own.
+            // //let requested_languages = DesktopLanguageRequester::requested_languages();
+            
+            // let li: unic_langid::LanguageIdentifier = ajour.language_state.current_language_name.parse()
+            // .expect("Parsing failed.");
+            // let mut requested_languages = Vec::new();
+            // requested_languages.push(li);
+        
+            // log::debug!("Requested languages {:?}", requested_languages);
+        
+            // let _result = i18n_embed::select(
+            //     &language_loader, &translations, &requested_languages);
         }
         Message::ThemeSelected(theme_name) => {
             log::debug!("Message::ThemeSelected({:?})", &theme_name);

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -23,9 +23,10 @@ use {
     std::collections::{HashMap, HashSet},
     std::path::{Path, PathBuf},
     widgets::header::ResizeEvent,
+    locale_config::Locale,
 };
 
-pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Message>> {
+pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Message>> {    
     match message {
         Message::Parse(Ok(config)) => {
             log::debug!("Message::Parse");

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -760,6 +760,14 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 }
             };
         }
+        Message::LanguageSelected(language_name) => {
+            log::debug!("Message::LanguageSelected({:?})", &language_name);
+
+            ajour.language_state.current_language_name = language_name.clone();
+
+            ajour.config.language = Some(language_name);
+            let _ = ajour.config.save();
+        }
         Message::ThemeSelected(theme_name) => {
             log::debug!("Message::ThemeSelected({:?})", &theme_name);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,26 +8,19 @@ mod gui;
 
 use ajour_core::fs::CONFIG_DIR;
 use ajour_core::Result;
-
+use i18n_embed::{DesktopLanguageRequester, gettext::{
+    gettext_language_loader
+},unic_langid};
 use rust_embed::RustEmbed;
 
-use i18n_embed::{gettext::GettextLanguageLoader,gettext::gettext_language_loader, DesktopLanguageRequester, LanguageRequester,
-    DefaultLocalizer, Localizer, unic_langid::LanguageIdentifier};
-use std::rc::Rc;
-use lazy_static::lazy_static;
-
 #[derive(RustEmbed)]
-#[folder = "i18n/mo"] // path to the compiled localization resources
+// path to the compiled localization resources,
+// as determined by i18n.toml settings
+#[folder = "i18n/mo"]
 struct Translations;
 
-const TRANSLATIONS: Translations = Translations {};
-
-lazy_static! {
-    static ref LANGUAGE_LOADER: GettextLanguageLoader = gettext_language_loader!();
-}
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
-
 
 pub fn main() {
     let opts = cli::get_opts();
@@ -45,17 +38,26 @@ pub fn main() {
 
     log::debug!("Ajour {} has started.", VERSION);
 
-    let localizer = DefaultLocalizer::new(&*LANGUAGE_LOADER, &TRANSLATIONS);
+    // let translations = Translations {};
 
-    let localizer_rc: Rc<dyn Localizer> = Rc::new(localizer);
+    // // Create the GettextLanguageLoader, pulling in settings from `i18n.toml`
+    // // at compile time using the macro.
+    // let language_loader = gettext_language_loader!();
 
-    let mut language_requester = DesktopLanguageRequester::new();
-    language_requester.add_listener(Rc::downgrade(&localizer_rc));
+    // // Use the language requester for the desktop platform (linux, windows, mac).
+    // // There is also a requester available for the web-sys WASM platform called
+    // // WebLanguageRequester, or you can implement your own.
+    // //let requested_languages = DesktopLanguageRequester::requested_languages();
+    
+    // let mut li: unic_langid::LanguageIdentifier = "fr".parse()
+    // .expect("Parsing failed.");
+    // let mut requested_languages = Vec::new();
+    // requested_languages.push(li);
 
-    // Manually check the currently requested system language,
-    // and update the listeners. When the system language changes,
-    // this will automatically be triggered.
-    language_requester.poll().unwrap(); 
+    // log::debug!("Requested languages {:?}", requested_languages);
+
+    // let _result = i18n_embed::select(
+    //     &language_loader, &translations, &requested_languages);
 
     // Start the GUI
     gui::run(opts);

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,6 @@ pub fn main() {
 
     log_panics::init();
 
-    log::debug!("{}", locale_config::Locale::user_default());
-
     log::debug!("Ajour {} has started.", VERSION);
 
     let translations = Translations {};

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,14 @@ mod gui;
 
 use ajour_core::Result;
 
+use rust_embed::RustEmbed;
+
+use i18n_embed::{gettext::gettext_language_loader, DesktopLanguageRequester};
+
+#[derive(RustEmbed)]
+#[folder = "i18n/mo"] // path to the compiled localization resources
+struct Translations;
+
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn main() {
@@ -15,7 +23,19 @@ pub fn main() {
 
     log_panics::init();
 
+    log::debug!("{}", locale_config::Locale::user_default());
+
     log::debug!("Ajour {} has started.", VERSION);
+
+    let translations = Translations {};
+    let language_loader = gettext_language_loader!();
+
+    // Use the language requester for the desktop platform (linux, windows, mac).
+    // There is also a requester available for the web-sys WASM platform called
+    // WebLanguageRequester, or you can implement your own.
+    let requested_languages = DesktopLanguageRequester::requested_languages();
+
+    let _result = i18n_embed::select(&language_loader, &translations, &requested_languages);
 
     // Start the GUI
     gui::run();


### PR DESCRIPTION
Hi there!

This is a proposal PR to add localization to the ajour app that I want to bring up for discussion. This is a big change and it most likely would affect any other future development because from the day you add localization, it always must be taken into account moving forward. So this is a tentative PR to see if that is something that you want to consider adding to Ajour.

I want to start right from the start by saying that I'm completely new to rust and so the code might not be very standard or efficient, but it worked well enough to warrant at least showing it so you can look and take a decision on whether or not you want it in your app.

I have used the `i18n-embed` and `tr` crates with the `cargo-i18n` and `xtr` tools to achieve the translation. All that is based on the well known **GNU gettext** toolkit for software translation. The added code works out the locale of the system and then presents the translated strings to the user based on that. (I.E. As opposed to a settings dropdown letting you choose between different languages). There are of course pros and cons to both approaches, but the one I chose was the simplest to implement since there is no intervention from the user.

It works for most of the labels of the application. Of course, it is kind of a pain to maintain because all the strings presented to the user are not in a central location, so the workflow process to keep everything up to date means scouring through the entire codebase looking for strings and encasing them inside the `tr!()` macro. For now, there's not a lot of text so it kind of work out all right. Of course, the most efficient approach, if you do want to consider adding translations to the app, would be to eventually centralize all user-facing strings so they are easily translated.

This is what this looks like on my Mac set to a french locale, with the strings translated.

![Ajour translated](https://i.imgur.com/RdaCqHW.png)

![Ajour translated](https://i.imgur.com/cAXbvXL.png)


Small caveat : On my Mac I can't figure out, for the life of me, how to make sure the translations get included in the Ajour.app content. The binary release from running `make binary` works and is translated, but not the `.app` file.

So let me know what you think of this. Looking forward to discuss this proposal with you.