### PR TITLE
fix: alpha channel didn't always correctly show the newest value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 ## [Unreleased]
 ### Fixed
+- Fixed a case where we would choose alpha even though it was older than stable.
 - Fixed fingerprinting where some addons would fail during fingerprinting due to invalid UTF-8 characters and missing files. These addons now successfully fingerprint.
 
 ## [0.4.0] - 2020-10-6

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -341,6 +341,13 @@ impl Addon {
             } else {
                 false
             };
+        let stable_newer_than_alpha =
+            if let (Some(stable_package), Some(alpha_package)) = (stable_package, alpha_package) {
+                // If stable is newer than alpha, we return that instead.
+                stable_package.file_id > alpha_package.file_id
+            } else {
+                false
+            };
         let beta_newer_than_alpha =
             if let (Some(beta_package), Some(alpha_package)) = (beta_package, alpha_package) {
                 // If beta is newer than alpha, we return that instead.
@@ -365,6 +372,10 @@ impl Addon {
                     }
 
                     return beta_package;
+                }
+
+                if stable_newer_than_alpha {
+                    return stable_package;
                 }
 
                 alpha_package


### PR DESCRIPTION
Fixes #199

## Proposed Changes
A little bug had sneaked pass my nose where the alpha release channel didn't always show the correct version. Sorry about that!
 
## Checklist

- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
