### PR TITLE
Workflow for automatic releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+on:
+  push:
+    tags:
+      - "*"
+
+name: Release
+
+jobs:
+  create-release:
+    name: "Create Release"
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create-release.outputs.upload_url }}
+    steps:
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+  release:
+    name: "Release"
+    needs: create-release
+    strategy:
+      matrix:
+        target:
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            cross: false
+            binary_path: target/x86_64-pc-windows-msvc/target/release/ajour.exe
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: false
+            binary_path: target/x86_64-unknown-linux-gnu/target/release/ajour
+          #- target: x86_64-apple-darwin
+          #  os: macos-latest
+          #  cross: false
+          #  binary_path: target/x86_64-apple-darwin/target/release/ajour
+    runs-on: ${{ matrix.target.os }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Get the version
+        id: get_version
+        shell: bash
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target.target }}
+          override: true
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: ${{ matrix.target.cross }}
+          command: build
+          args: --release --target=${{ matrix.target.target }}
+
+      - name: Copy release files
+        shell: bash
+        run: |
+          mkdir package
+          cp -R LICENSE README.md package/
+          cp ${{ matrix.target.binary_path }} package/
+
+      - name: Create Archive
+        shell: bash
+        if: matrix.target.os != 'windows-latest'
+        run: |
+          tar czvf ajour-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target.target }}.tar.gz -C package/ .
+
+      - name: Create Archive (Windows)
+        if: matrix.target.os == 'windows-latest'
+        run: |
+          cd package; 7z.exe a ../ajour-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target.target }}.zip .
+
+      - name: Upload Release Asset
+        if: matrix.target.os != 'windows-latest'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ./ajour-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target.target }}.tar.gz
+          asset_name: ajour-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target.target }}.tar.gz
+          asset_content_type: application/x-gzip
+
+      - name: Upload Release Asset (Windows)
+        if: matrix.target.os == 'windows-latest'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ./ajour-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target.target }}.zip
+          asset_name: ajour-${{ steps.get_version.outputs.VERSION }}-${{ matrix.target.target }}.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
This change adds a new workflow for automated releasing. After a maintainer pushes a new tag, code is built, packaged and released. 
ToDo's:
- [ ] add script for `.appimage` linux packaging
- [ ] create package for mac (need help here)

How to create release?
1. checkout development branch
2. commit your changes. *Commit message will be used as a release description*
3. `git tag x.x.x`
4. `git push origin x.x.x`

Resolves #

## Proposed Changes
  -
  -
  -

## Checklist

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
