### PR TITLE
Ci/release workflow

### DIFF
--- a/.github/workflows/release_to_draft.yml
+++ b/.github/workflows/release_to_draft.yml
@@ -1,4 +1,4 @@
-name: "Release matrix"
+name: "Release to draft"
 
 on:
   workflow_dispatch:
@@ -47,16 +47,10 @@ jobs:
 
       - name: "Windows wgpu?"
         if: ${{ matrix.os == 'windows' && matrix.gfx == 'wgpu' }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
+        run: make binary
       - name: "Windows OpenGL?"
         if: ${{ matrix.os == 'windows' && matrix.gfx == 'opengl' }} 
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --no-default-features --features opengl
+        run: make binary OPENGL=1
 
       - name: Upload AppImage wgpu
         if: ${{ matrix.os == 'ubuntu' && matrix.gfx == 'wgpu' }} 
@@ -87,13 +81,13 @@ jobs:
     needs: release
     name: "Create Release"
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Create Release
         id: create-release
         uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.event.inputs.tag }}
           release_name: ${{ github.event.inputs.tag }}
@@ -105,8 +99,6 @@ jobs:
 
       - name: Upload Linux wgpu asset
         uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
           asset_path: ./ubuntu-wgpu-artifact/ajour.AppImage
@@ -115,8 +107,6 @@ jobs:
 
       - name: Upload Linux OpenGL asset
         uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
           asset_path: ./ubuntu-opengl-artifact/ajour-opengl.AppImage
@@ -125,8 +115,6 @@ jobs:
 
       - name: Upload Windows wgpu asset
         uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
           asset_path: ./windows-wgpu-artifact/ajour.exe
@@ -135,8 +123,6 @@ jobs:
 
       - name: Upload Windows OpenGL asset
         uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
           asset_path: ./windows-opengl-artifact/ajour.exe
@@ -145,8 +131,6 @@ jobs:
 
       - name: Upload MacOS wgpu asset
         uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
           asset_path: ./macos-wgpu-artifact/ajour.dmg
@@ -155,8 +139,6 @@ jobs:
 
       - name: Upload MacOS OpenGL asset
         uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
           asset_path: ./macos-opengl-artifact/ajour.dmg

--- a/.github/workflows/release_to_draft.yml
+++ b/.github/workflows/release_to_draft.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [windows, ubuntu, macos] 
-        gfx: [vulkan, opengl]
+        gfx: [wgpu, opengl]
     runs-on: ${{ matrix.os }}-latest
 
     steps:
@@ -25,8 +25,8 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: "Linux Vulkan?"
-        if: ${{ matrix.os == 'ubuntu' && matrix.gfx == 'vulkan' }} 
+      - name: "Linux wgpu?"
+        if: ${{ matrix.os == 'ubuntu' && matrix.gfx == 'wgpu' }} 
         run: |
           wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
           chmod +x linuxdeploy-x86_64.AppImage
@@ -38,15 +38,15 @@ jobs:
           chmod +x linuxdeploy-x86_64.AppImage
           make binary appimage OPENGL=1
 
-      - name: "MacOS Vulkan?"
-        if: ${{ matrix.os == 'macos' && matrix.gfx == 'vulkan' }} 
+      - name: "MacOS wgpu?"
+        if: ${{ matrix.os == 'macos' && matrix.gfx == 'wgpu' }} 
         run: make binary dmg
       - name: "MacOS OpenGL?"
         if: ${{ matrix.os == 'macos' && matrix.gfx == 'opengl' }} 
         run: make binary dmg OpenGL=1
 
-      - name: "Windows Vulkan?"
-        if: ${{ matrix.os == 'windows' && matrix.gfx == 'vulkan' }}
+      - name: "Windows wgpu?"
+        if: ${{ matrix.os == 'windows' && matrix.gfx == 'wgpu' }}
         uses: actions-rs/cargo@v1
         with:
           command: build
@@ -58,8 +58,8 @@ jobs:
           command: build
           args: --release --no-default-features --features opengl
 
-      - name: Upload AppImage Vulkan
-        if: ${{ matrix.os == 'ubuntu' && matrix.gfx == 'vulkan' }} 
+      - name: Upload AppImage wgpu
+        if: ${{ matrix.os == 'ubuntu' && matrix.gfx == 'wgpu' }} 
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}-${{ matrix.gfx }}-artifact
@@ -103,13 +103,13 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v2
 
-      - name: Upload Linux Vulkan asset
+      - name: Upload Linux wgpu asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./ubuntu-vulkan-artifact/ajour.AppImage
+          asset_path: ./ubuntu-wgpu-artifact/ajour.AppImage
           asset_name: ajour.AppImage
           asset_content_type: application/x-executable
 
@@ -123,13 +123,13 @@ jobs:
           asset_name: ajour-opengl.AppImage
           asset_content_type: application/x-executable
 
-      - name: Upload Windows Vulkan asset
+      - name: Upload Windows wgpu asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./windows-vulkan-artifact/ajour.exe
+          asset_path: ./windows-wgpu-artifact/ajour.exe
           asset_name: ajour.exe
           asset_content_type: application/x-dosexec
 
@@ -143,13 +143,13 @@ jobs:
           asset_name: ajour-opengl.exe
           asset_content_type: application/x-dosexec
 
-      - name: Upload MacOS Vulkan asset
+      - name: Upload MacOS wgpu asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./macos-vulkan-artifact/ajour.dmg
+          asset_path: ./macos-wgpu-artifact/ajour.dmg
           asset_name: ajour.dmg
           asset_content_type: application/octet-stream
 

--- a/.github/workflows/release_to_draft.yml
+++ b/.github/workflows/release_to_draft.yml
@@ -1,0 +1,158 @@
+name: "Release matrix"
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Specify tag to create'
+        required: true
+
+jobs:
+  
+  release:
+    name: "Release"
+    strategy:
+      matrix:
+        os: [windows, ubuntu, macos] 
+        gfx: [vulkan, opengl]
+    runs-on: ${{ matrix.os }}-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: "Linux Vulkan?"
+        if: ${{ matrix.os == 'ubuntu' && matrix.gfx == 'vulkan' }} 
+        run: |
+          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          chmod +x linuxdeploy-x86_64.AppImage
+          make binary appimage
+      - name: "Linux OpenGL?"
+        if: ${{ matrix.os == 'ubuntu' && matrix.gfx == 'opengl' }} 
+        run: |
+          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          chmod +x linuxdeploy-x86_64.AppImage
+          make binary appimage OPENGL=1
+
+      - name: "MacOS Vulkan?"
+        if: ${{ matrix.os == 'macos' && matrix.gfx == 'vulkan' }} 
+        run: make binary dmg
+      - name: "MacOS OpenGL?"
+        if: ${{ matrix.os == 'macos' && matrix.gfx == 'opengl' }} 
+        run: make binary dmg OpenGL=1
+
+      - name: "Windows Vulkan?"
+        if: ${{ matrix.os == 'windows' && matrix.gfx == 'vulkan' }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+      - name: "Windows OpenGL?"
+        if: ${{ matrix.os == 'windows' && matrix.gfx == 'opengl' }} 
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --no-default-features --features opengl
+
+      - name: Upload AppImage
+        if: ${{ matrix.os == 'ubuntu' }} 
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.os }}-${{ matrix.gfx }}-artifact
+          path: ajour.AppImage
+      - name: Upload dmg
+        if: ${{ matrix.os == 'macos' }} 
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.os }}-${{ matrix.gfx }}-artifact
+          path: ajour.dmg
+      - name: Upload exe
+        if: ${{ matrix.os == 'windows' }} 
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.os }}-${{ matrix.gfx }}-artifact
+          path: ajour.exe
+
+  create-release:
+    needs: release
+    name: "Create Release"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.tag }}
+          release_name: ${{ github.event.inputs.tag }}
+          draft: true
+          prerelease: false
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Upload Linux Vulkan asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./ubuntu-vulkan-artifact/ajour
+          asset_name: ajour.AppImage
+          asset_content_type: application/x-executable
+
+      - name: Upload Linux OpenGL asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./ubuntu-opengl-artifact/ajour
+          asset_name: ajour-opengl.AppImage
+          asset_content_type: application/x-executable
+
+      - name: Upload Windows Vulkan asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./windows-vulkan-artifact/ajour
+          asset_name: ajour.exe
+          asset_content_type: application/x-dosexec
+
+      - name: Upload Windows OpenGL asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./windows-opengl-artifact/ajour
+          asset_name: ajour-opengl.exe
+          asset_content_type: application/x-dosexec
+
+      - name: Upload MacOS Vulkan asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./macos-vulkan-artifact/ajour
+          asset_name: ajour.dmg
+          asset_content_type: application/octet-stream
+
+      - name: Upload MacOS OpenGL asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./macos-opengl-artifact/ajour
+          asset_name: ajour-opengl.dmg
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release_to_draft.yml
+++ b/.github/workflows/release_to_draft.yml
@@ -43,7 +43,7 @@ jobs:
         run: make binary dmg
       - name: "MacOS OpenGL?"
         if: ${{ matrix.os == 'macos' && matrix.gfx == 'opengl' }} 
-        run: make binary dmg OpenGL=1
+        run: make binary dmg OPENGL=1
 
       - name: "Windows wgpu?"
         if: ${{ matrix.os == 'windows' && matrix.gfx == 'wgpu' }}
@@ -64,12 +64,18 @@ jobs:
         with:
           name: ${{ matrix.os }}-${{ matrix.gfx }}-artifact
           path: ajour-opengl.AppImage
-      - name: Upload dmg
-        if: ${{ matrix.os == 'macos' }} 
+      - name: Upload dmg wgpu
+        if: ${{ matrix.os == 'macos' && matrix.gfx == 'wgpu' }} 
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}-${{ matrix.gfx }}-artifact
           path: target/release/osx/ajour.dmg
+      - name: Upload dmg OpenGL
+        if: ${{ matrix.os == 'macos' && matrix.gfx == 'opengl' }} 
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.os }}-${{ matrix.gfx }}-artifact
+          path: target/release/osx/ajour-opengl.dmg
       - name: Upload exe
         if: ${{ matrix.os == 'windows' }} 
         uses: actions/upload-artifact@v2
@@ -141,6 +147,6 @@ jobs:
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./macos-opengl-artifact/ajour.dmg
+          asset_path: ./macos-opengl-artifact/ajour-opengl.dmg
           asset_name: ajour-opengl.dmg
           asset_content_type: application/octet-stream

--- a/.github/workflows/release_to_draft.yml
+++ b/.github/workflows/release_to_draft.yml
@@ -58,24 +58,30 @@ jobs:
           command: build
           args: --release --no-default-features --features opengl
 
-      - name: Upload AppImage
-        if: ${{ matrix.os == 'ubuntu' }} 
+      - name: Upload AppImage Vulkan
+        if: ${{ matrix.os == 'ubuntu' && matrix.gfx == 'vulkan' }} 
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}-${{ matrix.gfx }}-artifact
           path: ajour.AppImage
+      - name: Upload AppImage OpenGL
+        if: ${{ matrix.os == 'ubuntu' && matrix.gfx == 'opengl' }} 
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.os }}-${{ matrix.gfx }}-artifact
+          path: ajour-opengl.AppImage
       - name: Upload dmg
         if: ${{ matrix.os == 'macos' }} 
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}-${{ matrix.gfx }}-artifact
-          path: ajour.dmg
+          path: target/release/osx/ajour.dmg
       - name: Upload exe
         if: ${{ matrix.os == 'windows' }} 
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}-${{ matrix.gfx }}-artifact
-          path: ajour.exe
+          path: target/release/ajour.exe
 
   create-release:
     needs: release
@@ -103,7 +109,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./ubuntu-vulkan-artifact/ajour
+          asset_path: ./ubuntu-vulkan-artifact/ajour.AppImage
           asset_name: ajour.AppImage
           asset_content_type: application/x-executable
 
@@ -113,7 +119,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./ubuntu-opengl-artifact/ajour
+          asset_path: ./ubuntu-opengl-artifact/ajour-opengl.AppImage
           asset_name: ajour-opengl.AppImage
           asset_content_type: application/x-executable
 
@@ -123,7 +129,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./windows-vulkan-artifact/ajour
+          asset_path: ./windows-vulkan-artifact/ajour.exe
           asset_name: ajour.exe
           asset_content_type: application/x-dosexec
 
@@ -133,7 +139,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./windows-opengl-artifact/ajour
+          asset_path: ./windows-opengl-artifact/ajour.exe
           asset_name: ajour-opengl.exe
           asset_content_type: application/x-dosexec
 
@@ -143,7 +149,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./macos-vulkan-artifact/ajour
+          asset_path: ./macos-vulkan-artifact/ajour.dmg
           asset_name: ajour.dmg
           asset_content_type: application/octet-stream
 
@@ -153,6 +159,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./macos-opengl-artifact/ajour
+          asset_path: ./macos-opengl-artifact/ajour.dmg
           asset_name: ajour-opengl.dmg
           asset_content_type: application/octet-stream


### PR DESCRIPTION
Resolves #

## Proposed Changes
  - This adds a workflow that uses the workflow_dispatch event, meaning it can be triggered manually via the Actions tab.
  - It will use the makefile as it works at the moment on the ci/makefile branch to build all 6 assets (mac, win, lin x vulkan, opengl)
  - If the builds are successful it will create a new draft release and tag. And upload the 6 assets to it. 
  - It is still necessary to update the version in cargo and changelog.md prior to running the workflow, and to add the changelog section to the release description before publishing it.

## Checklist

- [ ] Tested on all platforms changed. The builds have not been tested (only that the windows versions start). I noticed the macos builds generated are identical in size with and without opengl.
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
