### PR TITLE
Fix/catalog no stable file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 ### Fixed
 - Fixed bug where orphaned folders could exist after updating an addon if the newer version of an addon didnt't include those folders anymore. 
+- Fixed catalog install buttons getting stuck when install fails or addon is unavailable to download. Button will now show "Retry" if failed and disabled as "Unavailable" if the addon is unavailable.
 
 ### Packaging
 - Added Forest Night theme

--- a/crates/core/src/curse_api.rs
+++ b/crates/core/src/curse_api.rs
@@ -163,7 +163,7 @@ pub async fn fetch_game_info() -> Result<GameInfo> {
     }
 }
 
-pub async fn latest_addon(curse_id: u32, flavor: Flavor) -> Result<(u32, Flavor, Addon)> {
+pub async fn latest_addon(curse_id: u32, flavor: Flavor) -> Result<Addon> {
     let packages: Vec<Package> = fetch_remote_packages_by_ids(&[curse_id]).await?;
 
     let package = packages.into_iter().next().ok_or_else(|| {
@@ -210,5 +210,5 @@ pub async fn latest_addon(curse_id: u32, flavor: Flavor) -> Result<(u32, Flavor,
 
     addon.set_title(package.name.clone());
 
-    Ok((curse_id, flavor, addon))
+    Ok(addon)
 }

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -498,7 +498,6 @@ pub async fn read_addon_directory<P: AsRef<Path>>(
         .cloned();
 
     let unknown_addons = unmapped_folders
-        .into_iter()
         .map(|f| {
             let mut addon = Addon::empty(&f.id);
             addon.folders = vec![f];

--- a/crates/core/src/tukui_api.rs
+++ b/crates/core/src/tukui_api.rs
@@ -72,14 +72,14 @@ pub async fn fetch_remote_package(id: &str, flavor: &Flavor) -> Result<TukuiPack
     }
 }
 
-pub async fn latest_addon(tukui_id: u32, flavor: Flavor) -> Result<(u32, Flavor, Addon)> {
+pub async fn latest_addon(tukui_id: u32, flavor: Flavor) -> Result<Addon> {
     let tukui_id_string = tukui_id.to_string();
 
     let package = fetch_remote_package(&tukui_id_string, &flavor).await?;
 
     let addon = Addon::from_tukui_package(tukui_id_string, &[], &package);
 
-    Ok((tukui_id, flavor, addon))
+    Ok(addon)
 }
 
 pub async fn fetch_changelog(id: &str, flavor: &Flavor) -> Result<(String, String)> {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -103,7 +103,7 @@ pub enum Message {
     None(()),
     Parse(Result<Config>),
     ParsedAddons((Flavor, Result<Vec<Addon>>)),
-    UpdateFingerprint((Flavor, String, Result<()>)),
+    UpdateFingerprint((DownloadReason, Flavor, String, Result<()>)),
     ThemeSelected(String),
     ReleaseChannelSelected(ReleaseChannel),
     ThemesLoaded(Vec<Theme>),
@@ -1122,7 +1122,9 @@ impl Default for CatalogSearchState {
 pub struct CatalogRow {
     website_state: button::State,
     retail_install_state: button::State,
+    retail_install_status: CatalogInstallStatus,
     classic_install_state: button::State,
+    classic_install_status: CatalogInstallStatus,
     addon: CatalogAddon,
 }
 
@@ -1131,10 +1133,23 @@ impl From<CatalogAddon> for CatalogRow {
         Self {
             website_state: Default::default(),
             retail_install_state: Default::default(),
+            retail_install_status: CatalogInstallStatus::None,
             classic_install_state: Default::default(),
+            classic_install_status: CatalogInstallStatus::None,
             addon,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum CatalogInstallStatus {
+    None,
+    Downloading,
+    Unpacking,
+    Fingerprint,
+    Completed,
+    Retry,
+    Unavilable,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -114,7 +114,7 @@ pub enum Message {
     LatestBackup(Option<NaiveDateTime>),
     BackupFinished(Result<NaiveDateTime>),
     CatalogDownloaded(Result<Catalog>),
-    CatalogInstallAddonFetched(Result<(u32, Flavor, Addon)>),
+    CatalogInstallAddonFetched((Flavor, u32, Result<Addon>)),
     FetchedCurseChangelog((Addon, AddonVersionKey, Result<(String, String)>)),
     FetchedTukuiChangelog((Addon, AddonVersionKey, Result<(String, String)>)),
 }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -834,7 +834,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                     if reason == DownloadReason::Install {
                         if let Some((_, _, status)) =
                             ajour.catalog_install_statuses.iter_mut().find(|(f, i, _)| {
-                                flavor == *f && addon.repository_id().unwrap() == i.to_string()
+                                flavor == *f && addon.repository_id() == Some(i.to_string())
                             })
                         {
                             *status = CatalogInstallStatus::Completed;
@@ -847,7 +847,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                     if reason == DownloadReason::Install {
                         if let Some((_, _, status)) =
                             ajour.catalog_install_statuses.iter_mut().find(|(f, i, _)| {
-                                flavor == *f && addon.repository_id().unwrap() == i.to_string()
+                                flavor == *f && addon.repository_id() == Some(i.to_string())
                             })
                         {
                             *status = CatalogInstallStatus::Retry;


### PR DESCRIPTION
Resolves #215 

It'd be nice to actually present an error to the user when an install fails. Maybe make the download button go red / disable with "Failed" and somewhere display a reason why ("No stable file available for addon"). But not sure the best way to handle that at this point. I'm happy leaving this PR open until we land on a good design choice for that

## Proposed Changes
  - If addon download fails, remove the "empty" placeholder addon so that it doesn't appear in "My Addons" and the install button reverts from being stuck on "Downloading"


## Checklist

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
