### PR TITLE
fix: add env variable to mac builds in workflow

### DIFF
--- a/.github/workflows/release_to_draft.yml
+++ b/.github/workflows/release_to_draft.yml
@@ -40,10 +40,10 @@ jobs:
 
       - name: "MacOS wgpu?"
         if: ${{ matrix.os == 'macos' && matrix.gfx == 'wgpu' }} 
-        run: make binary dmg
+        run: make binary dmg MACOS=1
       - name: "MacOS OpenGL?"
         if: ${{ matrix.os == 'macos' && matrix.gfx == 'opengl' }} 
-        run: make binary dmg OPENGL=1
+        run: make binary dmg OPENGL=1 MACOS=1
 
       - name: "Windows wgpu?"
         if: ${{ matrix.os == 'windows' && matrix.gfx == 'wgpu' }}


### PR DESCRIPTION
We didn't add `MACOS=1` to mac builds which meant we wouldn't set `MACOSX_DEPLOYMENT_TARGET="10.11"` which means that the build would only work on the latest version of macOS.