### PR TITLE
feat: able to open addon website from catalog

### DIFF
--- a/.github/workflows/release_to_draft.yml
+++ b/.github/workflows/release_to_draft.yml
@@ -40,10 +40,10 @@ jobs:
 
       - name: "MacOS wgpu?"
         if: ${{ matrix.os == 'macos' && matrix.gfx == 'wgpu' }} 
-        run: make binary dmg
+        run: make binary dmg MACOS=1
       - name: "MacOS OpenGL?"
         if: ${{ matrix.os == 'macos' && matrix.gfx == 'opengl' }} 
-        run: make binary dmg OPENGL=1
+        run: make binary dmg OPENGL=1 MACOS=1
 
       - name: "Windows wgpu?"
         if: ${{ matrix.os == 'windows' && matrix.gfx == 'wgpu' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` and `Removed`.
 
 ## [Unreleased]
+### Added
+- It is now possible to open the addon website for more information by pressing the title in the catalog
+
 ## [0.4.1] - 2020-10-11
 ### Added
 - 10 new themes has been bundled together with the application.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` and `Removed`.
 
 ## [Unreleased]
+## [0.4.1] - 2020-10-11
 ### Added
 - 10 new themes has been bundled together with the application.
   - The way you define a theme has been refactored so we can define more nuances.

--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -57,6 +57,7 @@ pub struct Catalog {
 #[derive(Debug, Clone, Deserialize)]
 pub struct CatalogAddon {
     pub id: u32,
+    pub website_url: String,
     pub name: String,
     pub categories: Vec<String>,
     pub summary: String,

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -1329,6 +1329,7 @@ pub fn catalog_data_cell<'a, 'b>(
     let mut row_containers = vec![];
 
     let addon_data = &addon.addon;
+    let website_state = &mut addon.website_state;
     let retail_install_state = &mut addon.retail_install_state;
     let classic_install_state = &mut addon.classic_install_state;
 
@@ -1454,11 +1455,15 @@ pub fn catalog_data_cell<'a, 'b>(
         .next()
     {
         let title = Text::new(&addon_data.name).size(DEFAULT_FONT_SIZE);
-        let title_container = Container::new(title)
+        let title_button: Element<Interaction> = Button::new(website_state, title)
+            .style(style::BrightTextButton(color_palette))
+            .on_press(Interaction::OpenLink(addon_data.website_url.clone()))
+            .into();
+
+        let title_container = Container::new(title_button.map(Message::Interaction))
             .height(default_height)
             .width(*width)
             .center_y()
-            .padding(5)
             .style(style::BrightForegroundContainer(color_palette));
 
         row_containers.push((idx, title_container));

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1085,6 +1085,7 @@ impl Default for CatalogSearchState {
 }
 
 pub struct CatalogRow {
+    website_state: button::State,
     retail_install_state: button::State,
     classic_install_state: button::State,
     addon: CatalogAddon,
@@ -1093,6 +1094,7 @@ pub struct CatalogRow {
 impl From<CatalogAddon> for CatalogRow {
     fn from(addon: CatalogAddon) -> Self {
         Self {
+            website_state: Default::default(),
             retail_install_state: Default::default(),
             classic_install_state: Default::default(),
             addon,


### PR DESCRIPTION
Resolves #223

## Proposed Changes
  - It is now possible to open the addon website for more information by pressing the title in the catalog.

## Checklist

- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
