### PR TITLE
always refresh folders on update or install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
   - Curse addons that have been locally modified should now display properly in Ajour. A `Repair` button will be present which will install the latest version of the addon so Ajour can accurately track the addon without local modifications.
   - Addons that can't match to any registry will now show up in Ajour as status `Unknown`. Addons that have multiple folders will not be grouped and instead we will show one entry for every folder.
 
+### Fixed
+- Fixed bug where orphaned folders could exist after updating an addon if the newer version of an addon didnt't include those folders anymore. 
+
 ### Packaging
 - Added Forest Night theme
 

--- a/crates/core/src/fs/addon.rs
+++ b/crates/core/src/fs/addon.rs
@@ -30,19 +30,16 @@ pub async fn install_addon(
     let mut zip_file = std::fs::File::open(&zip_path)?;
     let mut archive = zip::ZipArchive::new(&mut zip_file)?;
 
+    // Remove old addon folders
+    for folder in addon.folders.iter() {
+        let _ = std::fs::remove_dir_all(&folder.path);
+    }
+
     let mut toc_files = vec![];
 
     for i in 0..archive.len() {
         let mut file = archive.by_index(i)?;
         let path = to_directory.join(file.sanitized_name());
-
-        // If top-level destination folder for addon, delete that folder to remove
-        // the previous version so we guarantee a clean copy
-        if let Some(parent) = path.parent() {
-            if parent == to_directory {
-                let _ = std::fs::remove_dir_all(&path);
-            }
-        }
 
         if let Some(ext) = path.extension() {
             if let Ok(remainder) = path.strip_prefix(to_directory) {

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -646,7 +646,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 }
             }
         }
-        Message::UnpackedAddon((reason, flavor, id, result)) => {
+        Message::UnpackedAddon((_reason, flavor, id, result)) => {
             log::debug!(
                 "Message::UnpackedAddon(({}, error: {}))",
                 &id,
@@ -657,10 +657,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             if let Some(addon) = addons.iter_mut().find(|a| a.primary_folder_id == id) {
                 match result {
                     Ok(mut folders) => {
-                        // If we are installing the addon through the catalog, we need to update
-                        // the AddonFolders and Primary Folder Id of the addon since
-                        // they have not yet been set
-                        if reason == DownloadReason::Install {
+                        // Update the folders of the addon since they could have changed from the update,
+                        // or if its an addon installed through the catalog, we haven't assigned it folders yet
+                        {
                             folders.sort_by(|a, b| a.id.cmp(&b.id));
 
                             // Assign the primary folder id based on the first folder alphabetically with


### PR DESCRIPTION
This fixes a couple potential bugs... If an update to an addon has a different list of `AddonFolder` than the currently installed addon, it used to leave those old folders on the filesystem. Then the new fallback logic would show those orphaned folders as "Uknown". We now delete all top level folders based on the `Addon`s `folders` prior to extracting the new addon folders.

We also make sure that these new addon folders are parsed and assigned to the addon not only on Catalog Install, but on Update as well. This should always keep the folders of the Addon accurate.

## Checklist

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
