### PR TITLE
Fix/remove all folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 ### Fixed
 - Fixed bug where orphaned folders could exist after updating an addon if the newer version of an addon didnt't include those folders anymore. 
+- Ensure symlinks are removed in the addons folder prior to extracting an addon, so we don't write into the symlink and instead remove the link / create a new folder.
+  - This is a request from a developer who symlinks their source code into the addons folder and Ajour could accidently overwrite it
 
 ### Packaging
 - Added Forest Night theme

--- a/crates/core/src/fs/addon.rs
+++ b/crates/core/src/fs/addon.rs
@@ -3,6 +3,7 @@ use crate::{
     parse::parse_toc_path,
     Result,
 };
+use std::collections::HashSet;
 use std::fs::remove_dir_all;
 use std::path::PathBuf;
 
@@ -30,9 +31,26 @@ pub async fn install_addon(
     let mut zip_file = std::fs::File::open(&zip_path)?;
     let mut archive = zip::ZipArchive::new(&mut zip_file)?;
 
-    // Remove old addon folders
+    // Remove old top level addon folders
     for folder in addon.folders.iter() {
         let _ = std::fs::remove_dir_all(&folder.path);
+    }
+
+    // Get all new top level folders
+    let new_top_level_folders = archive
+        .file_names()
+        .filter_map(|name| name.split('/').next())
+        .collect::<HashSet<_>>();
+
+    // Remove all new top level addon folders. This seems redundant because of
+    // the remove old expression above, but that one doesn't work on new addons
+    // installed from the Catalog.
+    for folder in new_top_level_folders {
+        let path = to_directory.join(&folder);
+
+        if path.exists() {
+            let _ = std::fs::remove_dir_all(path);
+        }
     }
 
     let mut toc_files = vec![];
@@ -46,14 +64,6 @@ pub async fn install_addon(
                 if ext == "toc" && remainder.components().count() == 2 {
                     toc_files.push(path.clone());
                 }
-            }
-        }
-
-        // Remove remaining addon folders that match new addon folders that we
-        // want to extract.
-        if let Ok(remainder) = path.strip_prefix(to_directory) {
-            if remainder.components().count() == 1 && path.is_dir() {
-                let _ = std::fs::remove_dir_all(&path);
             }
         }
 

--- a/crates/core/src/fs/addon.rs
+++ b/crates/core/src/fs/addon.rs
@@ -49,6 +49,14 @@ pub async fn install_addon(
             }
         }
 
+        // Remove remaining addon folders that match new addon folders that we
+        // want to extract.
+        if let Ok(remainder) = path.strip_prefix(to_directory) {
+            if remainder.components().count() == 1 && path.is_dir() {
+                let _ = std::fs::remove_dir_all(&path);
+            }
+        }
+
         if file.is_dir() {
             std::fs::create_dir_all(&path)?;
         } else {


### PR DESCRIPTION
Resolves #255

## Proposed Changes
  - The old logic for removing destination folders seemed to sometimes not run depending on how the zip file got extracted. This new logic guarantees that the top level addon destination folder will get deleted before we extract. This function also removes symlinks, which resolves #255.


## Checklist

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
