### PR TITLE
chore: reverted hide of some modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` and `Removed`.
 
 ## [Unreleased]
+### Fixed
+- Now correctly shows all sub-addons if they are a seperate addons.
+  - An example is Altoholic-Retail (Teelo's Fork). All it's dependencies are actually standalone addons. They are now correctly shown.
+
 ## [0.4.3] - 2020-10-22
 
 ### Fixed

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -517,21 +517,6 @@ pub async fn read_addon_directory<P: AsRef<Path>>(
 
     concatenated.extend(unknown_addons);
 
-    // We do a extra clean up here to ensure that we dont display any addons which is a module.
-    // Idea is that we loop the addon.folders and mark all "dependencies".
-    // We then retain them from the concatenated Vec. If there is any.
-    let mut marked = vec![];
-    for addon in &concatenated {
-        for folder in &addon.folders {
-            if folder.id != addon.primary_folder_id {
-                marked.push(folder.id.clone());
-            }
-        }
-    }
-
-    // Remove dependency addons.
-    concatenated.retain(|addon| !marked.iter().any(|id| &addon.primary_folder_id == id));
-
     Ok(concatenated)
 }
 


### PR DESCRIPTION
Resolves #284.

## Proposed Changes
  - We now show modules if they are a match. Previously I added some logic to avoid this, but that was a mistake. We all make mistakes apparently.

## Checklist

- [X] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
