### PR TITLE
chore: unwrap could cause ajour to crash

### DIFF
--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -480,14 +480,13 @@ impl Addon {
                 && info.file.modules.iter().any(|m| m.foldername == f.id)
         }) {
             f.id.clone()
+        } else if let Some(f) = addon_folders
+            .iter()
+            .find(|f| info.file.modules.iter().any(|m| m.foldername == f.id))
+        {
+            f.id.clone()
         } else {
-            addon_folders
-                .iter()
-                .find(|f| info.file.modules.iter().any(|m| m.foldername == f.id))
-                .as_ref()
-                .unwrap()
-                .id
-                .clone()
+            info.file.file_name.clone()
         };
 
         let mut addon = Addon::empty(&primary_folder_id);


### PR DESCRIPTION
## Proposed Changes
  - In a rare case we assumed a little too much, and was met with a crash. I am playing a bit more defensive now and do not assume the data from CurseForge is good.
