### PR TITLE
fix: remove fingerprint dependency from when you install from catalog

### DIFF
--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -393,14 +393,13 @@ impl Addon {
                 && file.modules.iter().any(|m| m.foldername == f.id)
         }) {
             f.id.clone()
+        } else if let Some(f) = addon_folders
+            .iter()
+            .find(|f| file.modules.iter().any(|m| m.foldername == f.id))
+        {
+            f.id.clone()
         } else {
-            addon_folders
-                .iter()
-                .find(|f| file.modules.iter().any(|m| m.foldername == f.id))
-                .as_ref()
-                .unwrap()
-                .id
-                .clone()
+            file.file_name.clone()
         };
 
         let mut addon = Addon::empty(&primary_folder_id);

--- a/crates/core/src/curse_api.rs
+++ b/crates/core/src/curse_api.rs
@@ -177,43 +177,7 @@ pub async fn latest_addon(curse_id: u32, flavor: Flavor) -> Result<Addon> {
         ClientError::Custom(format!("No package found for curse id {}", curse_id))
     })?;
 
-    let stable_file = package
-        .latest_files
-        .iter()
-        .find(|f| {
-            f.release_type == 1 && f.game_version_flavor.as_ref() == Some(&flavor.curse_format())
-        })
-        .ok_or_else(|| {
-            ClientError::Custom(format!("No stable file found for curse id {}", curse_id))
-        })?;
-
-    let first_fingerprint = stable_file
-        .modules
-        .iter()
-        .map(|f| f.fingerprint)
-        .next()
-        .ok_or_else(|| {
-            ClientError::Custom(format!(
-                "No stable file fingerprint found for curse id {}",
-                curse_id
-            ))
-        })?;
-
-    let fingerprint_info = fetch_remote_packages_by_fingerprint(&[first_fingerprint]).await?;
-
-    let info = if let Some(info) = fingerprint_info.exact_matches.get(0) {
-        info
-    } else {
-        fingerprint_info.partial_matches.get(0).ok_or_else(|| {
-            ClientError::Custom(format!(
-                "No fingerprint match for curse id {}, fingerprint {}",
-                curse_id, first_fingerprint
-            ))
-        })?
-    };
-
-    let mut addon = Addon::from_curse_fingerprint_info(curse_id, info, flavor, &[]);
-
+    let mut addon = Addon::from_curse_package(&package, flavor, &[]).unwrap();
     addon.set_title(package.name.clone());
 
     Ok(addon)

--- a/crates/core/src/curse_api.rs
+++ b/crates/core/src/curse_api.rs
@@ -178,7 +178,7 @@ pub async fn latest_addon(curse_id: u32, flavor: Flavor) -> Result<Addon> {
     })?;
 
     let mut addon = Addon::from_curse_package(&package, flavor, &[]).unwrap();
-    addon.set_title(package.name.clone());
+    addon.set_title(package.name);
 
     Ok(addon)
 }


### PR DESCRIPTION
## Proposed Changes
Previously we did a fingerprint check to CurseForge. This we don't do anymore now.
For backlog @tarkah – let's talk about this when you are back.

## Checklist

- [X] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
