### PR TITLE
fix bug creating addons from already matched curse ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` and `Removed`.
 
 ## [Unreleased]
+
+### Fixed
+- Fixed an issue where forked addons from the curse API would show both versions of the addon in Ajour instead of only the one actually installed.
+
+## [0.4.4] - 2020-10-23
+
 ### Fixed
 - Fixed issue where Tukui addons would delete dependency standalone addons during update.
 - Now correctly shows all sub-addons if they are a seperate addons.

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -393,9 +393,11 @@ pub async fn read_addon_directory<P: AsRef<Path>>(
     let mut curse_ids_from_nonmatch: Vec<_> = addon_folders
         .iter()
         .filter(|f| {
-            fingerprint_addons
-                .iter()
-                .any(|fa| fa.primary_folder_id != f.id)
+            !fingerprint_addons.iter().any(|fa| {
+                fa.folders
+                    .iter()
+                    .any(|faf| faf.fingerprint == f.fingerprint)
+            })
         })
         .filter(|f| {
             f.repository_identifiers.tukui.is_none() && f.repository_identifiers.curse.is_some()


### PR DESCRIPTION
Resolves issue with Altoholic brought up in Discord

## Proposed Changes
  - Any folder with a curse id that is already successfully mapped via an exact fingerprint match shouldn't allow a new addon to be created from that curse id. I've fixed a logic gap that allowed this to happen previously.

## Checklist

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
