### PR TITLE
feat: identify wowinterface addons 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 ## [Unreleased]
 
+### Added
+- Ajour now has WoWInterface as a source.
+
 ### Fixed
 - Fixed an issue where forked addons from the curse API would show both versions of the addon in Ajour instead of only the one actually installed.
 

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -89,11 +89,25 @@ pub struct RepositoryIdentifiers {
     pub curse: Option<u32>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq)]
 pub enum Repository {
-    WowI,
-    Tukui,
     Curse,
+    Tukui,
+    WowI,
+}
+
+impl std::fmt::Display for Repository {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Repository::WowI => "WoWInterface",
+                Repository::Tukui => "Tukui",
+                Repository::Curse => "CurseForge",
+            }
+        )
+    }
 }
 
 /// Struct that stores the metadata parsed from an Addon folder's

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -324,7 +324,7 @@ impl Addon {
 
         let mut addon = Addon::empty(&primary_folder_id);
         addon.active_repository = Some(Repository::WowI);
-        addon.repository_identifiers.tukui = Some(wowi_id);
+        addon.repository_identifiers.wowi = Some(wowi_id);
         addon.repository_metadata = metadata;
 
         // Get folders that match primary folder id or any folder that has a dependency

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod parse;
 pub mod theme;
 pub mod tukui_api;
 pub mod utility;
+pub mod wowi_api;
 
 use crate::error::ClientError;
 

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -485,7 +485,7 @@ pub async fn read_addon_directory<P: AsRef<Path>>(
             .filter_map(|folder| {
                 if let (Some(wowi_id), None, None) = (
                     folder.repository_identifiers.wowi.clone(),
-                    folder.repository_identifiers.curse.clone(),
+                    folder.repository_identifiers.curse,
                     folder.repository_identifiers.tukui.clone(),
                 ) {
                     Some(wowi_id)

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -490,7 +490,11 @@ pub async fn read_addon_directory<P: AsRef<Path>>(
                     .any(|faf| faf.fingerprint == f.fingerprint)
             })
         })
-        .filter(|f| f.repository_identifiers.wowi.is_some())
+        .filter(|f| {
+            f.repository_identifiers.tukui.is_none()
+                && f.repository_identifiers.curse.is_none()
+                && f.repository_identifiers.wowi.is_some()
+        })
         .map(|f| f.repository_identifiers.wowi.clone().unwrap())
         .collect();
     wowi_ids_from_nonmatch.dedup();

--- a/crates/core/src/wowi_api.rs
+++ b/crates/core/src/wowi_api.rs
@@ -1,0 +1,53 @@
+use crate::{error::ClientError, network::request_async, Result};
+use isahc::config::RedirectPolicy;
+use isahc::prelude::*;
+use serde::Deserialize;
+
+const API_ENDPOINT: &str = "https://api.mmoui.com/v4/game/WOW/filedetails";
+const ADDON_URL: &str = "https://www.wowinterface.com/downloads/info";
+
+/// Return the wowi API endpoint.
+fn api_endpoint(ids: &str) -> String {
+    format!("{}/{}.json", API_ENDPOINT, ids)
+}
+
+/// Returns the addon website url.
+pub fn addon_url(id: &str) -> String {
+    format!("{}{}", ADDON_URL, id)
+}
+
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Deserialize)]
+/// Struct for applying wowi details to an `Addon`.
+pub struct WowIPackage {
+    pub id: i64,
+    pub title: String,
+    pub version: String,
+    pub download_uri: String,
+    pub last_update: i64,
+    pub author: String,
+    pub description: String,
+}
+
+/// Function to fetch a remote addon package which contains
+/// information about the addon on the repository.
+pub async fn fetch_remote_packages(ids: Vec<String>) -> Result<Vec<WowIPackage>> {
+    let client = HttpClient::builder()
+        .redirect_policy(RedirectPolicy::Follow)
+        .max_connections_per_host(6)
+        .build()
+        .unwrap();
+    let url = api_endpoint(&ids.join(","));
+    let timeout = Some(30);
+    let mut resp = request_async(&client, &url, vec![], timeout).await?;
+
+    if resp.status().is_success() {
+        let packages = resp.json();
+        Ok(packages.unwrap())
+    } else {
+        Err(ClientError::Custom(format!(
+            "Couldn't fetch details for addon. Server returned: {}",
+            resp.text()?
+        )))
+    }
+}

--- a/crates/core/src/wowi_api.rs
+++ b/crates/core/src/wowi_api.rs
@@ -29,6 +29,11 @@ pub struct WowIPackage {
     pub description: String,
 }
 
+/// Returns changelog url for addon.
+pub fn changelog_url(id: String) -> String {
+    format!("{}{}/#changelog", ADDON_URL, id)
+}
+
 /// Function to fetch a remote addon package which contains
 /// information about the addon on the repository.
 pub async fn fetch_remote_packages(ids: Vec<String>) -> Result<Vec<WowIPackage>> {

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -254,7 +254,7 @@ pub fn settings_container<'a, 'b>(
     let (columns_title_row, columns_scrollable) = {
         // Title for the Columns section.
         let columns_title_text = Text::new("Columns").size(DEFAULT_FONT_SIZE);
-        let columns_title_row = Row::new().push(columns_title_text).padding(DEFAULT_PADDING);
+        let columns_title_row = Row::new().push(columns_title_text);
 
         // Scrollable for column selections
         let mut columns_scrollable = Scrollable::new(&mut column_settings.scrollable_state)
@@ -344,7 +344,6 @@ pub fn settings_container<'a, 'b>(
 
     // Colum wrapping all the settings content.
     let left_column = Column::new()
-        .push(Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING)))
         .push(directory_info_text)
         .push(Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING)))
         .push(path_data_row)
@@ -360,7 +359,6 @@ pub fn settings_container<'a, 'b>(
         .push(bottom_space);
 
     let middle_column = Column::new()
-        .push(Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING)))
         .push(scale_title_row)
         .push(Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING)))
         .push(scale_buttons_row)
@@ -389,7 +387,7 @@ pub fn settings_container<'a, 'b>(
         .push(Space::new(Length::Fill, Length::Units(DEFAULT_PADDING)));
     let right_container = Container::new(right_column)
         .width(Length::Units(200))
-        .height(Length::Units(265))
+        .height(Length::Units(268))
         .style(style::BrightForegroundContainer(color_palette));
 
     // Row to wrap each section.
@@ -404,7 +402,7 @@ pub fn settings_container<'a, 'b>(
     Container::new(row)
         .height(Length::Shrink)
         .style(style::BrightForegroundContainer(color_palette))
-        .padding(DEFAULT_PADDING + DEFAULT_PADDING)
+        .padding(DEFAULT_PADDING)
 }
 
 pub fn addon_data_cell<'a, 'b>(
@@ -722,6 +720,32 @@ pub fn addon_data_cell<'a, 'b>(
         .iter()
         .enumerate()
         .filter_map(|(idx, (key, width, hidden))| {
+            if *key == ColumnKey::Source && !hidden {
+                Some((idx, width))
+            } else {
+                None
+            }
+        })
+        .next()
+    {
+        let source_text = addon
+            .active_repository
+            .map_or_else(|| String::from("Unknown"), |a| a.to_string());
+        let source = Text::new(source_text).size(DEFAULT_FONT_SIZE);
+        let source_container = Container::new(source)
+            .height(default_height)
+            .width(*width)
+            .center_y()
+            .padding(5)
+            .style(style::NormalForegroundContainer(color_palette));
+
+        row_containers.push((idx, source_container));
+    }
+
+    if let Some((idx, width)) = column_config
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, (key, width, hidden))| {
             if *key == ColumnKey::Status && !hidden {
                 Some((idx, width))
             } else {
@@ -795,7 +819,7 @@ pub fn addon_data_cell<'a, 'b>(
                 .center_x()
                 .padding(5)
                 .style(style::NormalForegroundContainer(color_palette)),
-            AddonState::Unknown => Container::new(Text::new("Unknown").size(DEFAULT_FONT_SIZE))
+            AddonState::Unknown => Container::new(Text::new("").size(DEFAULT_FONT_SIZE))
                 .height(default_height)
                 .width(*width)
                 .center_y()

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -519,6 +519,13 @@ pub fn addon_data_cell<'a, 'b>(
                 )));
         }
 
+        if addon_cloned.active_repository == Some(Repository::WowI) {
+            local_version_button =
+                local_version_button.on_press(Interaction::Expand(ExpandType::Changelog(
+                    Changelog::Request(addon_cloned.clone(), AddonVersionKey::Local),
+                )));
+        }
+
         // Lets check if addon is expanded, in changelog mode and local is shown.
         if is_addon_expanded {
             if let ExpandType::Changelog(Changelog::Some(_, _, k)) = expand_type {
@@ -577,6 +584,13 @@ pub fn addon_data_cell<'a, 'b>(
         if addon_cloned.active_repository == Some(Repository::Tukui)
             && addon_cloned.repository_id().is_some()
         {
+            remote_version_button =
+                remote_version_button.on_press(Interaction::Expand(ExpandType::Changelog(
+                    Changelog::Request(addon_cloned.clone(), AddonVersionKey::Remote),
+                )));
+        }
+
+        if addon_cloned.active_repository == Some(Repository::WowI) {
             remote_version_button =
                 remote_version_button.on_press(Interaction::Expand(ExpandType::Changelog(
                     Changelog::Request(addon_cloned.clone(), AddonVersionKey::Remote),

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -114,8 +114,7 @@ pub enum Message {
     BackupFinished(Result<NaiveDateTime>),
     CatalogDownloaded(Result<Catalog>),
     CatalogInstallAddonFetched((Flavor, u32, Result<Addon>)),
-    FetchedCurseChangelog((Addon, AddonVersionKey, Result<(String, String)>)),
-    FetchedTukuiChangelog((Addon, AddonVersionKey, Result<(String, String)>)),
+    FetchedChangelog((Addon, AddonVersionKey, Result<(String, String)>)),
 }
 
 pub struct Ajour {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -659,6 +659,7 @@ pub enum ColumnKey {
     Author,
     GameVersion,
     DateReleased,
+    Source,
 }
 
 impl ColumnKey {
@@ -674,6 +675,7 @@ impl ColumnKey {
             Author => "Author",
             GameVersion => "Game Version",
             DateReleased => "Latest Release",
+            Source => "Source",
         };
 
         title.to_string()
@@ -691,6 +693,7 @@ impl ColumnKey {
             Author => "author",
             GameVersion => "game_version",
             DateReleased => "date_released",
+            Source => "source",
         };
 
         s.to_string()
@@ -708,6 +711,7 @@ impl From<&str> for ColumnKey {
             "author" => ColumnKey::Author,
             "game_version" => ColumnKey::GameVersion,
             "date_released" => ColumnKey::DateReleased,
+            "source" => ColumnKey::Source,
             _ => panic!(format!("Unknown ColumnKey for {}", s)),
         }
     }
@@ -807,6 +811,13 @@ impl Default for HeaderState {
                     hidden: true,
                     order: 7,
                 },
+                ColumnState {
+                    key: ColumnKey::Source,
+                    btn_state: Default::default(),
+                    width: Length::Units(110),
+                    hidden: true,
+                    order: 8,
+                },
             ],
         }
     }
@@ -892,6 +903,12 @@ impl Default for ColumnSettings {
                 ColumnSettingState {
                     key: ColumnKey::DateReleased,
                     order: 7,
+                    up_btn_state: Default::default(),
+                    down_btn_state: Default::default(),
+                },
+                ColumnSettingState {
+                    key: ColumnKey::Source,
+                    order: 8,
                     up_btn_state: Default::default(),
                     down_btn_state: Default::default(),
                 },

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1623,6 +1623,12 @@ fn sort_addons(addons: &mut [Addon], sort_direction: SortDirection, column_key: 
                     .reverse()
             });
         }
+        (ColumnKey::Source, SortDirection::Asc) => {
+            addons.sort_by(|a, b| a.active_repository.cmp(&b.active_repository))
+        }
+        (ColumnKey::Source, SortDirection::Desc) => {
+            addons.sort_by(|a, b| a.active_repository.cmp(&b.active_repository).reverse())
+        }
     }
 }
 


### PR DESCRIPTION
Resolves #224

## Proposed Changes
  - Add WoWInterface as a source.
  - Add "Source" column as a new column to see where an addon is matched towards.
  - Removed "Unknown" addons from Status column. and moved it to Source column.

## Checklist

- [x] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
