### PR TITLE
Fixed unnecessary config clone

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: getajour

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![Continuous integration](https://github.com/casperstorm/ajour/workflows/Continuous-integration/badge.svg)
 ![Security audit](https://github.com/casperstorm/ajour/workflows/Security%20audit/badge.svg)
 [![Discord Server](https://img.shields.io/discord/757155234500968459?label=Discord%20Chat&labelColor=3C424A&logo=discord&logoColor=ffffff&color=7389D8)](https://discord.gg/4838t9R)
+[![Ajour on Patreon](https://img.shields.io/static/v1?label=Patreon&message=Ajour&color=4d898b)](https://www.patreon.com/getajour) 
 
 ![](./resources/screenshots/ajour-banner.jpg)
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Ajour is a World of Warcraft addon manager written in Rust with a strong focus o
 - Bulk addon update without any limitations
 - Remove addons and their dependencies
 - Ignore addons you don't want to update
-- Supports both Retail and Classic version of World of Warcraft
+- Supports both Retail, Classic, PTR and Beta versions of World of Warcraft
 - 10+ handcrafted themes to choose between
   - [Ability to add your own custom themes](./THEMES.md)
 - Ability to backup your whole UI, including all settings from WTF

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -1123,7 +1123,7 @@ pub fn menu_addons_container<'a>(
     refresh_button_state: &'a mut button::State,
     state: &AjourState,
     addons: &[Addon],
-    config: &'a mut Config,
+    config: &Config,
 ) -> Container<'a, Message> {
     // A row contain general settings.
     let mut settings_row = Row::new().height(Length::Units(35));

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -236,10 +236,6 @@ impl Application for Ajour {
     }
 
     fn view(&mut self) -> Element<Message> {
-        // Clone config to be used.
-        // FIXME: This could be done prettier.
-        let cloned_config = self.config.clone();
-
         // Get color palette of chosen theme.
         let color_palette = self
             .theme_state
@@ -292,7 +288,7 @@ impl Application for Ajour {
             let settings_container = element::settings_container(
                 color_palette,
                 &mut self.directory_btn_state,
-                &cloned_config,
+                &self.config,
                 &mut self.theme_state,
                 &mut self.scale_state,
                 &mut self.backup_state,
@@ -325,7 +321,7 @@ impl Application for Ajour {
                     &mut self.refresh_btn_state,
                     &self.state,
                     addons,
-                    &mut self.config,
+                    &self.config,
                 );
                 content = content.push(menu_addons_container);
 


### PR DESCRIPTION
A code optimization that removes an unnecessary clone of the config to be able to pass it elsewhere as a mutable reference.

This doesn't resolve any outstanding issue and I don't believe that this requires a CHANGELOG entry.
