### PR TITLE
fix: 301

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` and `Removed`.
 
 ## [Unreleased]
-
+### Fixed
+- Cancelling when changing wow path will empty list 
 ### Packaging
 - The linux `AppImage` release assets are now built on Ubuntu 16.04 (Xenial) to improve support.
 

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -330,10 +330,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             let path = wow_path_resolution(chosen_path);
             log::debug!("Message::UpdateWowDirectory(Resolution({:?}))", &path);
 
-            // Clear addons.
-            ajour.addons = HashMap::new();
-
             if path.is_some() {
+                // Clear addons.
+                ajour.addons = HashMap::new();
                 // Update the path for World of Warcraft.
                 ajour.config.wow.directory = path;
                 // Persist the newly updated config.


### PR DESCRIPTION
Resolves #301 

## Proposed Changes
  - We cleared the addon map a little too fast. This is now fixed so we only clear if we have a proper path.

## Checklist

- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
