### PR TITLE
fix: better regex for parsing changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 ## [Unreleased]
 ### Fixed
 - Cancelling when changing wow path will empty list 
+- Better changelog formatting
 ### Packaging
 - The linux `AppImage` release assets are now built on Ubuntu 16.04 (Xenial) to improve support.
 

--- a/crates/core/src/utility.rs
+++ b/crates/core/src/utility.rs
@@ -28,7 +28,7 @@ pub fn regex_html_tags_to_newline() -> Regex {
 }
 
 pub fn regex_html_tags_to_space() -> Regex {
-    regex::Regex::new(r"&nbsp;|&quot;|&lt;|&gt;|&amp;|gt;|lt;|&#x27;|<.+?>").unwrap()
+    regex::Regex::new(r"<[^>]*>|&#?\w+;|\b[gl]t;").unwrap()
 }
 
 #[derive(Deserialize)]

--- a/crates/core/src/utility.rs
+++ b/crates/core/src/utility.rs
@@ -28,7 +28,7 @@ pub fn regex_html_tags_to_newline() -> Regex {
 }
 
 pub fn regex_html_tags_to_space() -> Regex {
-    regex::Regex::new(r"<[^>]*>|&#?\w+;|\b[gl]t;").unwrap()
+    regex::Regex::new(r"<[^>]*>|&#?\w+;|[gl]t;").unwrap()
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Resolve issue posted on Discord:

![unknown](https://user-images.githubusercontent.com/2248455/97146726-a3f96400-1768-11eb-94d7-7c1c6816dc82.png)

Updated the regex for parsing changelog. It will not catch and fix the above.

## Checklist

- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
