### PR TITLE
Feat/make mac tar targets

### DIFF
--- a/.github/workflows/release_to_draft.yml
+++ b/.github/workflows/release_to_draft.yml
@@ -65,8 +65,8 @@ jobs:
           wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
           chmod +x linuxdeploy-x86_64.AppImage
 
-      - name: Install GNU tar for macos # Fix for macos caching, https://github.com/actions/cache/issues/403
-        if: contains(${{ matrix.target.target }},"-tar")
+      - name: Do we need GNU tar? # Fix for macos caching, https://github.com/actions/cache/issues/403
+        if: contains('${{ matrix.target.make }}',' tar')
         run: |
           brew install gnu-tar
           echo "::add-path::/usr/local/opt/gnu-tar/libexec/gnubin"

--- a/.github/workflows/release_to_draft.yml
+++ b/.github/workflows/release_to_draft.yml
@@ -25,21 +25,29 @@ jobs:
 
           - target: linux-wgpu
             os: ubuntu-16.04
-            make: make binary appimage
+            make: make appimage
             binary_path: ajour.AppImage
           - target: linux-opengl
             os: ubuntu-16.04
-            make: make binary appimage OPENGL=1
+            make: make appimage OPENGL=1
             binary_path: ajour-opengl.AppImage
 
           - target: macos-wgpu
             os: macos-latest
-            make: make binary dmg MACOS=1
+            make: make dmg MACOS=1
             binary_path: target/release/osx/ajour.dmg
           - target: macos-opengl
             os: macos-latest
-            make: make binary dmg OPENGL=1 MACOS=1
+            make: make dmg OPENGL=1 MACOS=1
             binary_path: target/release/osx/ajour-opengl.dmg
+          - target: macos-wgpu-tar
+            os: macos-latest
+            make: make tar MACOS=1
+            binary_path: target/release/ajour.tar.gz
+          - target: macos-opengl-tar
+            os: macos-latest
+            make: make tar OPENGL=1 MACOS=1
+            binary_path: target/release/ajour.tar.gz
 
     runs-on: ${{ matrix.target.os }}
 
@@ -118,6 +126,14 @@ jobs:
             artifact_name: ajour-opengl.dmg
             asset_name: ajour-opengl.dmg
             asset_type: application/octet-stream
+          - artifact: macos-wgpu-tar
+            artifact_name: ajour.tar.gz
+            asset_name: ajour.tar.gz
+            asset_type: application/gzip
+          - artifact: macos-opengl-tar
+            artifact_name: ajour.tar.gz
+            asset_name: ajour-opengl.tar.gz
+            asset_type: application/gzip
 
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/release_to_draft.yml
+++ b/.github/workflows/release_to_draft.yml
@@ -133,8 +133,8 @@ jobs:
             asset_name: ajour-opengl.dmg
             asset_type: application/octet-stream
           - artifact: macos-wgpu-tar
-            artifact_name: ajour-macos.tar.gz
-            asset_name: ajour.tar.gz
+            artifact_name: ajour.tar.gz
+            asset_name: ajour-macos.tar.gz
             asset_type: application/gzip
           - artifact: macos-opengl-tar
             artifact_name: ajour.tar.gz

--- a/.github/workflows/release_to_draft.yml
+++ b/.github/workflows/release_to_draft.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   
   build:
-    name: "Build"
+    name: Build
     strategy:
       matrix:
         target:
@@ -59,19 +59,19 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: "Do we need linuxdeploy?"
+      - name: Do we need linuxdeploy?
         if: ${{ matrix.target.os == 'ubuntu-16.04' }} 
         run: |
           wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
           chmod +x linuxdeploy-x86_64.AppImage
 
       - name: Do we need GNU tar? # Fix for macos caching, https://github.com/actions/cache/issues/403
-        if: contains('${{ matrix.target.make }}',' tar')
+        if: ${{ matrix.target.os == 'macos-latest' }}
         run: |
           brew install gnu-tar
           echo "::add-path::/usr/local/opt/gnu-tar/libexec/gnubin"
 
-      - name: "Build"
+      - name: Build
         run: ${{ matrix.target.make }}
 
       - name: Upload artifact
@@ -82,7 +82,7 @@ jobs:
 
   create-release:
     needs: build
-    name: "Create Release"
+    name: Create Release
     outputs:
       upload_url: ${{ steps.create-release.outputs.upload_url }}
     runs-on: ubuntu-latest
@@ -101,7 +101,7 @@ jobs:
 
   add-assets:
     needs: create-release
-    name: "Add Assets"
+    name: Add Assets
 
     strategy:
       matrix:

--- a/.github/workflows/release_to_draft.yml
+++ b/.github/workflows/release_to_draft.yml
@@ -65,6 +65,12 @@ jobs:
           wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
           chmod +x linuxdeploy-x86_64.AppImage
 
+      - name: Install GNU tar for macos # Fix for macos caching, https://github.com/actions/cache/issues/403
+        if: contains(${{ matrix.target.target }},"-tar")
+        run: |
+          brew install gnu-tar
+          echo "::add-path::/usr/local/opt/gnu-tar/libexec/gnubin"
+
       - name: "Build"
         run: ${{ matrix.target.make }}
 
@@ -127,12 +133,12 @@ jobs:
             asset_name: ajour-opengl.dmg
             asset_type: application/octet-stream
           - artifact: macos-wgpu-tar
-            artifact_name: ajour.tar.gz
+            artifact_name: ajour-macos.tar.gz
             asset_name: ajour.tar.gz
             asset_type: application/gzip
           - artifact: macos-opengl-tar
             artifact_name: ajour.tar.gz
-            asset_name: ajour-opengl.tar.gz
+            asset_name: ajour-opengl-macos.tar.gz
             asset_type: application/gzip
 
     runs-on: ubuntu-latest

--- a/.github/workflows/release_to_draft.yml
+++ b/.github/workflows/release_to_draft.yml
@@ -69,7 +69,7 @@ jobs:
         if: ${{ matrix.target.os == 'macos-latest' }}
         run: |
           brew install gnu-tar
-          echo "::add-path::/usr/local/opt/gnu-tar/libexec/gnubin"
+          echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
 
       - name: Build
         run: ${{ matrix.target.make }}


### PR DESCRIPTION
Resolves #

## Proposed Changes
  - Added 2 additional targets. The workflow now also creates tar.gz assets for macos, to be used by the self-updater logic in next release.

## Checklist

- [x] Tested on all platforms changed
Tested new assets can be run on macos.
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
N/A - the packaging entry for self-updater will suffice.