### PR TITLE
fix: no stable package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 ## [Unreleased]
 ### Fixed
+- Some addons failed to install through the catalog.
 - Cancelling when changing wow path will empty list.
 - Fixed case-sensitive issue when sorting addons by title. 
 - Better addon changelog formatting.

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -779,6 +779,20 @@ impl Addon {
         false
     }
 
+    /// Returns the first release_package which is `Some`.
+    pub fn fallback_release_package(&self) -> Option<&RemotePackage> {
+        let remote_packages = &self.repository_metadata.remote_packages;
+        if let Some(stable_package) = remote_packages.get(&ReleaseChannel::Stable) {
+            Some(stable_package)
+        } else if let Some(beta_package) = remote_packages.get(&ReleaseChannel::Beta) {
+            Some(beta_package)
+        } else if let Some(alpha_package) = remote_packages.get(&ReleaseChannel::Alpha) {
+            Some(alpha_package)
+        } else {
+            None
+        }
+    }
+
     /// Returns the relevant release_package for the addon.
     /// Logic is that if a release channel above the selected is newer, we return that instead.
     pub fn relevant_release_package(&self) -> Option<&RemotePackage> {

--- a/crates/core/src/network.rs
+++ b/crates/core/src/network.rs
@@ -64,7 +64,15 @@ pub async fn download_addon(
     addon: &Addon,
     to_directory: &PathBuf,
 ) -> Result<()> {
-    if let Some(package) = addon.relevant_release_package() {
+    let package = if let Some(relevant_package) = addon.relevant_release_package() {
+        Some(relevant_package)
+    } else if let Some(fallback_package) = addon.fallback_release_package() {
+        Some(fallback_package)
+    } else {
+        None
+    };
+
+    if let Some(package) = package {
         log::debug!(
             "downloading remote version {} for {}",
             package.version,


### PR DESCRIPTION
## Proposed Changes
  - If you installed a addon through the catalog which had no stable release, Ajour couldn't handle it.
  - I've made a fallback solution now so it tries tries different release channels before failing in the end.

## Checklist

- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
