### PR TITLE
feat: Addon Cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ dependencies = [
  "fancy-regex",
  "fern",
  "flate2",
+ "futures",
  "glob",
  "iced_native",
  "isahc",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -41,6 +41,7 @@ log = "0.4"
 fern = "0.6"
 walkdir = "2.3"
 retry = "1.1"
+futures = "0.3"
 
 iced_native = { git = "https://github.com/hecrj/iced.git", rev = "d3b04bf892ce63d3129686968039c258945c5b02", optional = true }
 

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -89,7 +89,7 @@ pub struct RepositoryIdentifiers {
     pub curse: Option<u32>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq, Serialize, Deserialize)]
 pub enum Repository {
     Curse,
     Tukui,
@@ -356,7 +356,7 @@ impl Addon {
                         &format!("{} 00:00:00", &package.lastupdate),
                         "%Y-%m-%d %T",
                     ),
-                    Result::Ok,
+                    std::result::Result::Ok,
                 )
                 .map(|d| Utc.from_utc_datetime(&d))
                 .ok();

--- a/crates/core/src/bin/parse_addon_directory.rs
+++ b/crates/core/src/bin/parse_addon_directory.rs
@@ -34,7 +34,7 @@ fn main() {
     let path = args.next().unwrap();
     let fingerprints_idx = args.position(|a| a == "--fingerprints");
 
-    let collection = if let Some(idx) = fingerprints_idx {
+    let fingerprint_cache = if let Some(idx) = fingerprints_idx {
         let path = args
             .nth(idx)
             .expect("--fingerprints must be followed by a path");
@@ -43,13 +43,13 @@ fn main() {
 
         let collection = serde_yaml::from_reader(&file).expect("not a valid fingerprints file");
 
-        Arc::new(Mutex::new(Some(collection)))
+        Some(Arc::new(Mutex::new(collection)))
     } else {
-        Arc::new(Mutex::new(None))
+        None
     };
 
     task::block_on(async move {
-        let addons = read_addon_directory(collection, &path, Flavor::Classic)
+        let addons = read_addon_directory(fingerprint_cache, &path, Flavor::Classic)
             .await
             .unwrap();
 

--- a/crates/core/src/bin/parse_addon_directory.rs
+++ b/crates/core/src/bin/parse_addon_directory.rs
@@ -1,9 +1,12 @@
+use ajour_core::cache::load_addon_cache;
 use ajour_core::config::Flavor;
 use ajour_core::parse::read_addon_directory;
+
 use async_std::{
     sync::{Arc, Mutex},
     task,
 };
+
 use std::env;
 use std::fs::File;
 
@@ -49,7 +52,9 @@ fn main() {
     };
 
     task::block_on(async move {
-        let addons = read_addon_directory(fingerprint_cache, &path, Flavor::Classic)
+        let addon_cache = Some(Arc::new(Mutex::new(load_addon_cache().await.unwrap())));
+
+        let addons = read_addon_directory(addon_cache, fingerprint_cache, &path, Flavor::Classic)
             .await
             .unwrap();
 

--- a/crates/core/src/cache.rs
+++ b/crates/core/src/cache.rs
@@ -1,0 +1,118 @@
+use crate::addon::{Addon, Repository};
+use crate::config::Flavor;
+use crate::fs::{config_dir, PersistentData};
+use crate::parse::Fingerprint;
+use crate::Result;
+
+use async_std::fs::rename;
+use async_std::sync::{Arc, Mutex};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct FingerprintCache(HashMap<Flavor, Vec<Fingerprint>>);
+
+impl FingerprintCache {
+    pub fn get_mut_for_flavor(&mut self, flavor: Flavor) -> &mut Vec<Fingerprint> {
+        self.0.entry(flavor).or_default()
+    }
+}
+
+impl PersistentData for FingerprintCache {
+    fn relative_path() -> PathBuf {
+        PathBuf::from("cache/fingerprints.yml")
+    }
+}
+
+pub async fn load_fingerprint_cache() -> Result<FingerprintCache> {
+    // Migrate from the old location to the new location, if exists
+    {
+        let old_location = config_dir().join("fingerprints.yml");
+
+        if old_location.exists() {
+            let new_location = FingerprintCache::path()?;
+
+            let _ = rename(old_location, new_location).await;
+        }
+    }
+
+    FingerprintCache::load_or_default()
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum AddonCache {
+    V1(HashMap<Flavor, Vec<AddonCacheEntry>>),
+}
+
+impl Default for AddonCache {
+    fn default() -> Self {
+        AddonCache::V1(Default::default())
+    }
+}
+
+impl AddonCache {
+    pub fn get_mut_for_flavor(&mut self, flavor: Flavor) -> &mut Vec<AddonCacheEntry> {
+        match self {
+            AddonCache::V1(cache) => cache.entry(flavor).or_default(),
+        }
+    }
+}
+
+impl PersistentData for AddonCache {
+    fn relative_path() -> PathBuf {
+        PathBuf::from("cache/addons.yml")
+    }
+}
+
+pub async fn load_addon_cache() -> Result<AddonCache> {
+    AddonCache::load_or_default()
+}
+
+pub async fn update_addon_cache(
+    addon_cache: Arc<Mutex<AddonCache>>,
+    entry: AddonCacheEntry,
+    flavor: Flavor,
+) -> Result<AddonCacheEntry> {
+    // Lock mutex to get mutable access and block other tasks from trying to update
+    let mut addon_cache = addon_cache.lock().await;
+
+    // Get entries for flavor
+    let entries = addon_cache.get_mut_for_flavor(flavor);
+
+    // Remove old entry, if it exists
+    entries.retain(|e| e.title != entry.title);
+
+    // Add new entry
+    entries.push(entry.clone());
+
+    // Persist changes to filesystem
+    let _ = addon_cache.save();
+
+    Ok(entry)
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct AddonCacheEntry {
+    pub title: String,
+    pub repository: Repository,
+    pub repository_id: String,
+    pub primary_folder_id: String,
+    pub folder_names: Vec<String>,
+    pub modified: DateTime<Utc>,
+}
+
+impl From<&Addon> for AddonCacheEntry {
+    fn from(addon: &Addon) -> Self {
+        AddonCacheEntry {
+            title: addon.title().to_owned(),
+            repository: addon.active_repository.unwrap(),
+            repository_id: addon.repository_id().unwrap(),
+            primary_folder_id: addon.primary_folder_id.clone(),
+            folder_names: addon.folders.iter().map(|a| a.id.clone()).collect(),
+            modified: Utc::now(),
+        }
+    }
+}

--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -8,7 +8,7 @@ use isahc::{config::RedirectPolicy, prelude::*};
 use serde::Deserialize;
 
 const CATALOG_URL: &str =
-    "https://raw.githubusercontent.com/casperstorm/ajour-catalog/master/curse.json";
+    "https://raw.githubusercontent.com/casperstorm/ajour-catalog/master/catalog.json";
 
 pub async fn get_catalog() -> Result<Catalog> {
     let client = HttpClient::builder()

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod addon;
 pub mod backup;
+pub mod cache;
 pub mod catalog;
 pub mod config;
 pub mod curse_api;

--- a/crates/core/src/wowi_api.rs
+++ b/crates/core/src/wowi_api.rs
@@ -48,7 +48,7 @@ pub async fn fetch_remote_packages(ids: Vec<String>) -> Result<Vec<WowIPackage>>
 
     if resp.status().is_success() {
         let packages = resp.json();
-        Ok(packages.unwrap())
+        Ok(packages?)
     } else {
         Err(ClientError::Custom(format!(
             "Couldn't fetch details for addon. Server returned: {}",

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -10,7 +10,7 @@ use ajour_core::{
     },
     catalog::get_catalog,
     catalog::{self, Catalog, CatalogAddon},
-    config::{ColumnConfigV2, Config, Flavor},
+    config::{ColumnConfig, ColumnConfigV2, Config, Flavor},
     error::ClientError,
     fs::PersistentData,
     theme::{load_user_themes, Theme},
@@ -106,7 +106,7 @@ pub enum Message {
     Interaction(Interaction),
     LatestRelease(Option<utility::Release>),
     None(()),
-    Parse(Result<Config>),
+    Parse(()),
     ParsedAddons((Flavor, Result<Vec<Addon>>)),
     UpdateFingerprint((DownloadReason, Flavor, String, Result<()>)),
     ThemeSelected(String),
@@ -214,9 +214,9 @@ impl Default for Ajour {
 impl Application for Ajour {
     type Executor = iced::executor::Default;
     type Message = Message;
-    type Flags = f64;
+    type Flags = Config;
 
-    fn new(scale: f64) -> (Self, Command<Message>) {
+    fn new(config: Config) -> (Self, Command<Message>) {
         let init_commands = vec![
             Command::perform(load_caches(), Message::CachesLoaded),
             Command::perform(get_latest_release(), Message::LatestRelease),
@@ -225,7 +225,8 @@ impl Application for Ajour {
         ];
 
         let mut ajour = Ajour::default();
-        ajour.scale_state.scale = scale;
+
+        apply_config(&mut ajour, config);
 
         (ajour, Command::batch(init_commands))
     }
@@ -636,7 +637,7 @@ pub fn run(opts: Opts) {
     let icon = iced::window::Icon::from_rgba(image.into_raw(), width, height);
     settings.window.icon = Some(icon.unwrap());
 
-    settings.flags = config.scale.unwrap_or(1.0);
+    settings.flags = config;
 
     // Runs the GUI.
     Ajour::run(settings).expect("running Ajour gui");
@@ -1410,4 +1411,177 @@ async fn load_caches() -> Result<(FingerprintCache, AddonCache)> {
     let addon_cache = load_addon_cache().await?;
 
     Ok((fingerprint_cache, addon_cache))
+}
+
+fn apply_config(ajour: &mut Ajour, config: Config) {
+    // Set column widths from the config
+    match &config.column_config {
+        ColumnConfig::V1 {
+            local_version_width,
+            remote_version_width,
+            status_width,
+        } => {
+            ajour
+                .header_state
+                .columns
+                .get_mut(1)
+                .as_mut()
+                .unwrap()
+                .width = Length::Units(*local_version_width);
+            ajour
+                .header_state
+                .columns
+                .get_mut(2)
+                .as_mut()
+                .unwrap()
+                .width = Length::Units(*remote_version_width);
+            ajour
+                .header_state
+                .columns
+                .get_mut(3)
+                .as_mut()
+                .unwrap()
+                .width = Length::Units(*status_width);
+        }
+        ColumnConfig::V2 { columns } => {
+            ajour.header_state.columns.iter_mut().for_each(|a| {
+                if let Some((idx, column)) = columns
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(idx, column)| {
+                        if column.key == a.key.as_string() {
+                            Some((idx, column))
+                        } else {
+                            None
+                        }
+                    })
+                    .next()
+                {
+                    a.width = column.width.map_or(Length::Fill, Length::Units);
+                    a.hidden = column.hidden;
+                    a.order = idx;
+                }
+            });
+
+            ajour.column_settings.columns.iter_mut().for_each(|a| {
+                if let Some(idx) = columns
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(idx, column)| {
+                        if column.key == a.key.as_string() {
+                            Some(idx)
+                        } else {
+                            None
+                        }
+                    })
+                    .next()
+                {
+                    a.order = idx;
+                }
+            });
+
+            // My Addons
+            ajour.header_state.columns.sort_by_key(|c| c.order);
+            ajour.column_settings.columns.sort_by_key(|c| c.order);
+        }
+        ColumnConfig::V3 {
+            my_addons_columns,
+            catalog_columns,
+        } => {
+            ajour.header_state.columns.iter_mut().for_each(|a| {
+                if let Some((idx, column)) = my_addons_columns
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(idx, column)| {
+                        if column.key == a.key.as_string() {
+                            Some((idx, column))
+                        } else {
+                            None
+                        }
+                    })
+                    .next()
+                {
+                    a.width = column.width.map_or(Length::Fill, Length::Units);
+                    a.hidden = column.hidden;
+                    a.order = idx;
+                }
+            });
+
+            ajour.column_settings.columns.iter_mut().for_each(|a| {
+                if let Some(idx) = my_addons_columns
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(idx, column)| {
+                        if column.key == a.key.as_string() {
+                            Some(idx)
+                        } else {
+                            None
+                        }
+                    })
+                    .next()
+                {
+                    a.order = idx;
+                }
+            });
+
+            ajour
+                .catalog_column_settings
+                .columns
+                .iter_mut()
+                .for_each(|a| {
+                    if let Some(idx) = catalog_columns
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(idx, column)| {
+                            if column.key == a.key.as_string() {
+                                Some(idx)
+                            } else {
+                                None
+                            }
+                        })
+                        .next()
+                    {
+                        a.order = idx;
+                    }
+                });
+
+            ajour.catalog_header_state.columns.iter_mut().for_each(|a| {
+                if let Some((idx, column)) = catalog_columns
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(idx, column)| {
+                        if column.key == a.key.as_string() {
+                            Some((idx, column))
+                        } else {
+                            None
+                        }
+                    })
+                    .next()
+                {
+                    a.width = column.width.map_or(Length::Fill, Length::Units);
+                    a.hidden = column.hidden;
+                    a.order = idx;
+                }
+            });
+
+            // My Addons
+            ajour.header_state.columns.sort_by_key(|c| c.order);
+            ajour.column_settings.columns.sort_by_key(|c| c.order);
+
+            // Catalog
+            ajour.catalog_header_state.columns.sort_by_key(|c| c.order);
+            ajour
+                .catalog_column_settings
+                .columns
+                .sort_by_key(|c| c.order);
+        }
+    }
+
+    // Use theme from config. Set to "Dark" if not defined.
+    ajour.theme_state.current_theme_name = config.theme.as_deref().unwrap_or("Dark").to_string();
+
+    // Use scale from config. Set to 1.0 if not defined.
+    ajour.scale_state.scale = config.scale.unwrap_or(1.0);
+
+    ajour.config = config;
 }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -8,7 +8,7 @@ use {
     ajour_core::{
         addon::{Addon, AddonFolder, AddonState, Repository},
         backup::{backup_folders, latest_backup, BackupFolder},
-        cache::{update_addon_cache, AddonCacheEntry, FingerprintCache},
+        cache::{update_addon_cache, AddonCache, AddonCacheEntry, FingerprintCache},
         catalog,
         config::{load_config, ColumnConfig, ColumnConfigV2, Flavor},
         curse_api,
@@ -214,6 +214,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
 
                     commands.push(Command::perform(
                         perform_read_addon_directory(
+                            ajour.addon_cache.clone(),
                             ajour.fingerprint_cache.clone(),
                             addon_directory.clone(),
                             *flavor,
@@ -1513,13 +1514,14 @@ async fn open_directory() -> Option<PathBuf> {
 }
 
 async fn perform_read_addon_directory(
+    addon_cache: Option<Arc<Mutex<AddonCache>>>,
     fingerprint_cache: Option<Arc<Mutex<FingerprintCache>>>,
     root_dir: PathBuf,
     flavor: Flavor,
 ) -> (Flavor, Result<Vec<Addon>>) {
     (
         flavor,
-        read_addon_directory(fingerprint_cache, root_dir, flavor).await,
+        read_addon_directory(addon_cache, fingerprint_cache, root_dir, flavor).await,
     )
 }
 

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -755,7 +755,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                     Ok(mut folders) => {
                         // Update the folders of the addon since they could have changed from the update,
                         // or if its an addon installed through the catalog, we haven't assigned it folders yet
-                        {
+                        if !folders.is_empty() {
                             folders.sort_by(|a, b| a.id.cmp(&b.id));
 
                             // Assign the primary folder id based on the first folder alphabetically with
@@ -784,7 +784,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                             }) {
                                 folder.id.clone()
                             } else {
-                                //TODO: Can this crash? What do we do in that case.
+                                // Wont fail since we already checked if vec is empty
                                 folders.get(0).map(|f| f.id.clone()).unwrap()
                             };
                             addon.primary_folder_id = primary_folder_id;

--- a/src/update.rs
+++ b/src/update.rs
@@ -2,11 +2,14 @@
 
 use crate::log_error;
 
-use ajour_core::addon::Addon;
-use ajour_core::cache::FingerprintCache;
+use ajour_core::addon::{Addon, Repository};
+use ajour_core::cache::{
+    load_addon_cache, load_fingerprint_cache, update_addon_cache, AddonCache, AddonCacheEntry,
+    FingerprintCache,
+};
 use ajour_core::config::{load_config, Flavor};
 use ajour_core::error::ClientError;
-use ajour_core::fs::{install_addon, PersistentData};
+use ajour_core::fs::install_addon;
 use ajour_core::network::download_addon;
 use ajour_core::parse::{read_addon_directory, update_addon_fingerprint};
 use ajour_core::Result;
@@ -28,7 +31,9 @@ pub fn update_all_addons() -> Result<()> {
         let config = load_config().await?;
 
         let fingerprint_cache: Arc<Mutex<_>> =
-            Arc::new(Mutex::new(FingerprintCache::load_or_default()?));
+            Arc::new(Mutex::new(load_fingerprint_cache().await?));
+
+        let addon_cache: Arc<Mutex<_>> = Arc::new(Mutex::new(load_addon_cache().await?));
 
         let mut addons_to_update = vec![];
 
@@ -46,9 +51,13 @@ pub fn update_all_addons() -> Result<()> {
             // Only returns None if the path isn't set in the config
             let addon_directory = config.get_addon_directory_for_flavor(flavor).ok_or_else(|| ClientError::Custom("No WoW directory set. Launch Ajour and make sure a WoW directory is set before using the command line.".to_string()))?;
 
-            if let Ok(addons) =
-                read_addon_directory(Some(fingerprint_cache.clone()), &addon_directory, *flavor)
-                    .await
+            if let Ok(addons) = read_addon_directory(
+                Some(addon_cache.clone()),
+                Some(fingerprint_cache.clone()),
+                &addon_directory,
+                *flavor,
+            )
+            .await
             {
                 // Get any saved release channel preferences from config
                 let release_channels = config
@@ -86,6 +95,7 @@ pub fn update_all_addons() -> Result<()> {
                         if addon.is_updatable(package) {
                             addons_to_update.push((
                                 shared_client.clone(),
+                                addon_cache.clone(),
                                 fingerprint_cache.clone(),
                                 *flavor,
                                 addon,
@@ -105,7 +115,7 @@ pub fn update_all_addons() -> Result<()> {
 
         addons_to_update
             .iter()
-            .for_each(|(_, _, flavor, addon, ..)| {
+            .for_each(|(_, _, _, flavor, addon, ..)| {
                 let current_version = addon.version().unwrap_or_default();
                 let new_version = addon
                     .relevant_release_package()
@@ -151,8 +161,17 @@ pub fn update_all_addons() -> Result<()> {
 ///
 /// Downloads the latest file, extracts it and refingerprints the addon, saving it to the cache.
 async fn update_addon(
-    (shared_client, fingerprint_cache, flavor, addon, temp_directory, addon_directory): (
+    (
+        shared_client,
+        addon_cache,
+        fingerprint_cache,
+        flavor,
+        mut addon,
+        temp_directory,
+        addon_directory,
+    ): (
         Arc<HttpClient>,
+        Arc<Mutex<AddonCache>>,
         Arc<Mutex<FingerprintCache>>,
         Flavor,
         Addon,
@@ -164,7 +183,37 @@ async fn update_addon(
     download_addon(&shared_client, &addon, &temp_directory).await?;
 
     // Extracts addon from the downloaded archive to the addon directory and removes the archive
-    install_addon(&addon, &temp_directory, &addon_directory).await?;
+    let mut installed_folders = install_addon(&addon, &temp_directory, &addon_directory).await?;
+
+    // Update addon based on installed folders
+    {
+        installed_folders.sort_by(|a, b| a.id.cmp(&b.id));
+
+        // Assign the primary folder id based on the first folder alphabetically with
+        // a matching repository identifier otherwise just the first
+        // folder alphabetically
+        let primary_folder_id = if let Some(folder) = installed_folders.iter().find(|f| {
+            if let Some(repo) = addon.active_repository {
+                match repo {
+                    Repository::Curse => {
+                        addon.repository_id()
+                            == f.repository_identifiers.curse.as_ref().map(u32::to_string)
+                    }
+                    Repository::Tukui => addon.repository_id() == f.repository_identifiers.tukui,
+                    Repository::WowI => addon.repository_id() == f.repository_identifiers.wowi,
+                }
+            } else {
+                false
+            }
+        }) {
+            folder.id.clone()
+        } else {
+            //TODO: Can this crash? What do we do in that case.
+            installed_folders.get(0).map(|f| f.id.clone()).unwrap()
+        };
+        addon.primary_folder_id = primary_folder_id;
+        addon.folders = installed_folders;
+    }
 
     // Stores each folder name we need to fingerprint
     let mut folders_to_fingerprint = vec![];
@@ -191,6 +240,15 @@ async fn update_addon(
             // Log any errors fingerprinting the folder
             log_error(&e);
         }
+    }
+
+    // Update cache for addon
+    if addon.active_repository == Some(Repository::Tukui)
+        || addon.active_repository == Some(Repository::WowI)
+    {
+        let entry = AddonCacheEntry::from(&addon);
+
+        update_addon_cache(addon_cache, entry, flavor).await?;
     }
 
     Ok(())


### PR DESCRIPTION
Resolves adding Tukui and WowI reliably to catalog

## Proposed Changes
  - Cache addon api and folder grouping data for Tukui and WowI addons installed through catalog since those APIs don't give us fingerprinting / modules like Curse and the addon folders are unreliable for getting repo IDs and impossible to determine grouping off of
  - Use this cache when parsing addons so we can reliably group / get repo metadata for these addons

## Checklist

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
