### PR TITLE
Fix/linux size scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 - Cancelling when changing wow path will empty list.
 - Fixed case-sensitive issue when sorting addons by title. 
 - Better addon changelog formatting.
+- Fixed bug on linux that caused window size to grow / shrink between sessions when a <>1.0 scale was set
 
 ### Packaging
 - Ajour can now self update when a new release is available. An "Update" button will appear along with a message that a newer release is available. Clicking this button will automatically update Ajour and relaunch it as the newer version.

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -201,9 +201,9 @@ impl Default for Ajour {
 impl Application for Ajour {
     type Executor = iced::executor::Default;
     type Message = Message;
-    type Flags = ();
+    type Flags = f64;
 
-    fn new(_flags: ()) -> (Self, Command<Message>) {
+    fn new(scale: f64) -> (Self, Command<Message>) {
         let init_commands = vec![
             Command::perform(load_config(), Message::Parse),
             Command::perform(get_latest_release(), Message::LatestRelease),
@@ -211,7 +211,10 @@ impl Application for Ajour {
             Command::perform(get_catalog(), Message::CatalogDownloaded),
         ];
 
-        (Ajour::default(), Command::batch(init_commands))
+        let mut ajour = Ajour::default();
+        ajour.scale_state.scale = scale;
+
+        (ajour, Command::batch(init_commands))
     }
 
     fn title(&self) -> String {
@@ -615,6 +618,8 @@ pub fn run(opts: Opts) {
     let (width, height) = image.dimensions();
     let icon = iced::window::Icon::from_rgba(image.into_raw(), width, height);
     settings.window.icon = Some(icon.unwrap());
+
+    settings.flags = config.scale.unwrap_or(1.0);
 
     // Runs the GUI.
     Ajour::run(settings).expect("running Ajour gui");

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1084,7 +1084,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
         Message::Interaction(Interaction::ScaleUp) => {
             let prev_scale = ajour.scale_state.scale;
 
-            ajour.scale_state.scale = (prev_scale + 0.1).min(2.0);
+            ajour.scale_state.scale = ((prev_scale + 0.1).min(2.0) * 10.0).round() / 10.0;
 
             ajour.config.scale = Some(ajour.scale_state.scale);
             let _ = ajour.config.save();
@@ -1098,7 +1098,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
         Message::Interaction(Interaction::ScaleDown) => {
             let prev_scale = ajour.scale_state.scale;
 
-            ajour.scale_state.scale = (prev_scale - 0.1).max(0.5);
+            ajour.scale_state.scale = ((prev_scale - 0.1).max(0.5) * 10.0).round() / 10.0;
 
             ajour.config.scale = Some(ajour.scale_state.scale);
             let _ = ajour.config.save();


### PR DESCRIPTION
Resolves #190 

## Proposed Changes
  - We pass the scale as a Application flag so our scale is set on the very first loop of our program. That way when the "rogue" resize event on linux is received, the dimensions aren't incorrectly changed by our scale factor adjustment logic. The problem was the "rogue" resize event happened before the config got loaded / scale was updated, so the resize event width / height weren't "scale adjusted" and then our scale adj logic fucked it up and saved it to the config, which then bit you in the ass on next launch.
  - I've also fixed the issue with saving floating point arithmetic unrounded numbers of the scale by forcing the f64 to round to 1 decimal place.

## Checklist

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
