### PR TITLE
chore: refactor state & mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 - Fixed case-sensitive issue when sorting addons by title. 
 - Better addon changelog formatting.
 - Fixed bug on linux that caused window size to grow / shrink between sessions when a <>1.0 scale was set
+- Fixed issue where Ajour sometimes shows a blank screen while content is loading.
 
 ### Packaging
 - Ajour can now self update when a new release is available. An "Update" button will appear along with a message that a newer release is available. Clicking this button will automatically update Ajour and relaunch it as the newer version.

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -2,10 +2,10 @@
 
 use {
     super::{
-        style, AddonVersionKey, AjourMode, AjourState, BackupState, CatalogColumnKey,
-        CatalogColumnSettings, CatalogColumnState, CatalogInstallStatus, CatalogRow, Changelog,
-        ColumnKey, ColumnSettings, ColumnState, DirectoryType, ExpandType, Interaction, Message,
-        ReleaseChannel, ScaleState, SelfUpdateState, SortDirection, ThemeState,
+        style, AddonVersionKey, BackupState, CatalogColumnKey, CatalogColumnSettings,
+        CatalogColumnState, CatalogInstallStatus, CatalogRow, Changelog, ColumnKey, ColumnSettings,
+        ColumnState, DirectoryType, ExpandType, Interaction, Message, Mode, ReleaseChannel,
+        ScaleState, SelfUpdateState, SortDirection, State, ThemeState,
     },
     crate::VERSION,
     ajour_core::{
@@ -20,6 +20,7 @@ use {
         HorizontalAlignment, Length, PickList, Row, Scrollable, Space, Text, VerticalAlignment,
     },
     num_format::{Locale, ToFormattedString},
+    std::collections::HashMap,
     widgets::{header, Header},
 };
 
@@ -32,7 +33,7 @@ pub fn settings_container<'a, 'b>(
     color_palette: ColorPalette,
     directory_button_state: &'a mut button::State,
     config: &Config,
-    mode: &AjourMode,
+    mode: &Mode,
     theme_state: &'a mut ThemeState,
     scale_state: &'a mut ScaleState,
     backup_state: &'a mut BackupState,
@@ -501,10 +502,10 @@ pub fn settings_container<'a, 'b>(
 
     // Depending on mode, we show different columns to edit.
     match mode {
-        AjourMode::MyAddons => {
+        Mode::MyAddons => {
             row = row.push(my_addons_columns_container);
         }
-        AjourMode::Catalog => {
+        Mode::Catalog => {
             row = row.push(catalog_columns_container);
         }
     }
@@ -1266,7 +1267,7 @@ pub fn addon_row_titles<'a>(
     .spacing(1)
     .height(Length::Units(25))
     .on_resize(3, |event| {
-        Message::Interaction(Interaction::ResizeColumn(AjourMode::MyAddons, event))
+        Message::Interaction(Interaction::ResizeColumn(Mode::MyAddons, event))
     })
 }
 
@@ -1275,10 +1276,14 @@ pub fn menu_addons_container<'a>(
     color_palette: ColorPalette,
     update_all_button_state: &'a mut button::State,
     refresh_button_state: &'a mut button::State,
-    state: &AjourState,
+    state: &HashMap<Mode, State>,
     addons: &[Addon],
     config: &Config,
 ) -> Container<'a, Message> {
+    // MyAddons state.
+    let default = &State::default();
+    let state = state.get(&Mode::MyAddons).unwrap_or(default);
+
     // A row contain general settings.
     let mut settings_row = Row::new().height(Length::Units(35));
 
@@ -1299,7 +1304,8 @@ pub fn menu_addons_container<'a>(
         .iter()
         .any(|a| matches!(a.state, AddonState::Downloading | AddonState::Unpacking));
 
-    let ajour_performing_actions = matches!(state, AjourState::Loading);
+    // TODO: Fix
+    let ajour_performing_actions = matches!(state, State::Loading);
 
     // Is any addon updtable.
     let any_addon_updatable = addons
@@ -1317,10 +1323,7 @@ pub fn menu_addons_container<'a>(
     // Enable refresh_button if:
     //   - No addon is performing any task.
     //   - Ajour isn't loading
-    if !addons_performing_actions
-        && !ajour_performing_actions
-        && !matches!(state, AjourState::Welcome)
-    {
+    if !addons_performing_actions && !ajour_performing_actions && !matches!(state, State::Start) {
         refresh_button = refresh_button.on_press(Interaction::Refresh);
     }
 
@@ -1336,7 +1339,7 @@ pub fn menu_addons_container<'a>(
         .count();
 
     let status_text = match state {
-        AjourState::Idle => Text::new(format!(
+        State::Ready => Text::new(format!(
             "{} {} addons loaded",
             parent_addons_count,
             config.wow.flavor.to_string()
@@ -1372,8 +1375,9 @@ pub fn menu_addons_container<'a>(
 #[allow(clippy::too_many_arguments)]
 pub fn menu_container<'a>(
     color_palette: ColorPalette,
-    mode: &AjourMode,
-    state: &AjourState,
+    mode: &Mode,
+    state: &HashMap<Mode, State>,
+    error: &Option<String>,
     config: &Config,
     valid_flavors: &[Flavor],
     settings_button_state: &'a mut button::State,
@@ -1386,6 +1390,10 @@ pub fn menu_container<'a>(
     classic_ptr_btn_state: &'a mut button::State,
     self_update_state: &'a mut SelfUpdateState,
 ) -> Container<'a, Message> {
+    // State.
+    let default = &State::default();
+    let myaddons_state = state.get(&Mode::MyAddons).unwrap_or(default);
+
     // A row contain general settings.
     let mut settings_row = Row::new().height(Length::Units(50));
 
@@ -1404,28 +1412,26 @@ pub fn menu_container<'a>(
     .style(style::DisabledDefaultButton(color_palette));
 
     match mode {
-        AjourMode::MyAddons => {
+        Mode::MyAddons => {
             addons_mode_button =
                 addons_mode_button.style(style::SelectedDefaultButton(color_palette));
             catalog_mode_button = catalog_mode_button.style(style::DefaultButton(color_palette));
         }
-        AjourMode::Catalog => {
+        Mode::Catalog => {
             addons_mode_button = addons_mode_button.style(style::DefaultButton(color_palette));
             catalog_mode_button =
                 catalog_mode_button.style(style::SelectedDefaultButton(color_palette));
         }
     }
 
-    // If we are onboarding, we disable the mode buttons and set proper styling.
-    if !matches!(state, AjourState::Welcome | AjourState::Loading) {
-        addons_mode_button =
-            addons_mode_button.on_press(Interaction::ModeSelected(AjourMode::MyAddons));
-        catalog_mode_button =
-            catalog_mode_button.on_press(Interaction::ModeSelected(AjourMode::Catalog));
-    } else {
+    if matches!(myaddons_state, State::Start) {
         addons_mode_button = addons_mode_button.style(style::DisabledDefaultButton(color_palette));
         catalog_mode_button =
             catalog_mode_button.style(style::DisabledDefaultButton(color_palette));
+    } else {
+        addons_mode_button = addons_mode_button.on_press(Interaction::ModeSelected(Mode::MyAddons));
+        catalog_mode_button =
+            catalog_mode_button.on_press(Interaction::ModeSelected(Mode::Catalog));
     }
 
     let addons_mode_button: Element<Interaction> = addons_mode_button.into();
@@ -1471,7 +1477,7 @@ pub fn menu_container<'a>(
     .style(style::DisabledDefaultButton(color_palette))
     .on_press(Interaction::FlavorSelected(Flavor::ClassicPTR));
 
-    let disable_flavor_buttons = matches!(state, AjourState::Welcome | AjourState::Loading);
+    let disable_flavor_buttons = matches!(myaddons_state, State::Start | State::Loading);
 
     if !disable_flavor_buttons {
         match config.wow.flavor {
@@ -1554,8 +1560,8 @@ pub fn menu_container<'a>(
     }
 
     // Displays an error, if any has occured.
-    let error_text = if let AjourState::Error(e) = state {
-        Text::new(e.to_string()).size(DEFAULT_FONT_SIZE)
+    let error_text = if let Some(error) = error {
+        Text::new(error).size(DEFAULT_FONT_SIZE)
     } else {
         // Display nothing.
         Text::new("")
@@ -1676,7 +1682,7 @@ pub fn status_container<'a>(
         .push(Space::new(Length::Units(0), Length::Units(2)))
         .push(description_container);
 
-    if let (_, Some(btn_state)) = (AjourState::Welcome, onboarding_directory_btn_state) {
+    if let (_, Some(btn_state)) = (State::Start, onboarding_directory_btn_state) {
         let onboarding_button_title_container =
             Container::new(Text::new("Select Directory").size(DEFAULT_FONT_SIZE))
                 .width(Length::Units(100))
@@ -1764,7 +1770,7 @@ pub fn catalog_row_titles<'a>(
     .spacing(1)
     .height(Length::Units(25))
     .on_resize(3, |event| {
-        Message::Interaction(Interaction::ResizeColumn(AjourMode::Catalog, event))
+        Message::Interaction(Interaction::ResizeColumn(Mode::Catalog, event))
     })
 }
 

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -502,7 +502,7 @@ pub fn settings_container<'a, 'b>(
 
     // Depending on mode, we show different columns to edit.
     match mode {
-        Mode::MyAddons => {
+        Mode::MyAddons(_) => {
             row = row.push(my_addons_columns_container);
         }
         Mode::Catalog => {
@@ -1267,13 +1267,17 @@ pub fn addon_row_titles<'a>(
     .spacing(1)
     .height(Length::Units(25))
     .on_resize(3, |event| {
-        Message::Interaction(Interaction::ResizeColumn(Mode::MyAddons, event))
+        Message::Interaction(Interaction::ResizeColumn(
+            Mode::MyAddons(Flavor::default()),
+            event,
+        ))
     })
 }
 
 #[allow(clippy::too_many_arguments)]
 pub fn menu_addons_container<'a>(
     color_palette: ColorPalette,
+    flavor: Flavor,
     update_all_button_state: &'a mut button::State,
     refresh_button_state: &'a mut button::State,
     state: &HashMap<Mode, State>,
@@ -1282,7 +1286,7 @@ pub fn menu_addons_container<'a>(
 ) -> Container<'a, Message> {
     // MyAddons state.
     let default = &State::default();
-    let state = state.get(&Mode::MyAddons).unwrap_or(default);
+    let state = state.get(&Mode::MyAddons(flavor)).unwrap_or(default);
 
     // A row contain general settings.
     let mut settings_row = Row::new().height(Length::Units(35));
@@ -1390,9 +1394,11 @@ pub fn menu_container<'a>(
     classic_ptr_btn_state: &'a mut button::State,
     self_update_state: &'a mut SelfUpdateState,
 ) -> Container<'a, Message> {
+    let flavor = config.wow.flavor;
+
     // State.
     let default = &State::default();
-    let myaddons_state = state.get(&Mode::MyAddons).unwrap_or(default);
+    let myaddons_state = state.get(&Mode::MyAddons(flavor)).unwrap_or(default);
 
     // A row contain general settings.
     let mut settings_row = Row::new().height(Length::Units(50));
@@ -1412,7 +1418,7 @@ pub fn menu_container<'a>(
     .style(style::DisabledDefaultButton(color_palette));
 
     match mode {
-        Mode::MyAddons => {
+        Mode::MyAddons(_) => {
             addons_mode_button =
                 addons_mode_button.style(style::SelectedDefaultButton(color_palette));
             catalog_mode_button = catalog_mode_button.style(style::DefaultButton(color_palette));
@@ -1429,7 +1435,8 @@ pub fn menu_container<'a>(
         catalog_mode_button =
             catalog_mode_button.style(style::DisabledDefaultButton(color_palette));
     } else {
-        addons_mode_button = addons_mode_button.on_press(Interaction::ModeSelected(Mode::MyAddons));
+        addons_mode_button =
+            addons_mode_button.on_press(Interaction::ModeSelected(Mode::MyAddons(flavor)));
         catalog_mode_button =
             catalog_mode_button.on_press(Interaction::ModeSelected(Mode::Catalog));
     }
@@ -1477,48 +1484,44 @@ pub fn menu_container<'a>(
     .style(style::DisabledDefaultButton(color_palette))
     .on_press(Interaction::FlavorSelected(Flavor::ClassicPTR));
 
-    let disable_flavor_buttons = matches!(myaddons_state, State::Start | State::Loading);
-
-    if !disable_flavor_buttons {
-        match config.wow.flavor {
-            Flavor::Retail => {
-                retail_button = retail_button.style(style::SelectedDefaultButton(color_palette));
-                retail_ptr_button = retail_ptr_button.style(style::DefaultButton(color_palette));
-                retail_beta_button = retail_beta_button.style(style::DefaultButton(color_palette));
-                classic_button = classic_button.style(style::DefaultButton(color_palette));
-                classic_ptr_button = classic_ptr_button.style(style::DefaultButton(color_palette));
-            }
-            Flavor::RetailPTR => {
-                retail_button = retail_button.style(style::DefaultButton(color_palette));
-                retail_ptr_button =
-                    retail_ptr_button.style(style::SelectedDefaultButton(color_palette));
-                retail_beta_button = retail_beta_button.style(style::DefaultButton(color_palette));
-                classic_button = classic_button.style(style::DefaultButton(color_palette));
-                classic_ptr_button = classic_ptr_button.style(style::DefaultButton(color_palette));
-            }
-            Flavor::RetailBeta => {
-                retail_button = retail_button.style(style::DefaultButton(color_palette));
-                retail_ptr_button = retail_ptr_button.style(style::DefaultButton(color_palette));
-                retail_beta_button =
-                    retail_beta_button.style(style::SelectedDefaultButton(color_palette));
-                classic_button = classic_button.style(style::DefaultButton(color_palette));
-                classic_ptr_button = classic_ptr_button.style(style::DefaultButton(color_palette));
-            }
-            Flavor::Classic => {
-                retail_button = retail_button.style(style::DefaultButton(color_palette));
-                retail_ptr_button = retail_ptr_button.style(style::DefaultButton(color_palette));
-                retail_beta_button = retail_beta_button.style(style::DefaultButton(color_palette));
-                classic_button = classic_button.style(style::SelectedDefaultButton(color_palette));
-                classic_ptr_button = classic_ptr_button.style(style::DefaultButton(color_palette));
-            }
-            Flavor::ClassicPTR => {
-                retail_button = retail_button.style(style::DefaultButton(color_palette));
-                retail_ptr_button = retail_ptr_button.style(style::DefaultButton(color_palette));
-                retail_beta_button = retail_beta_button.style(style::DefaultButton(color_palette));
-                classic_button = classic_button.style(style::DefaultButton(color_palette));
-                classic_ptr_button =
-                    classic_ptr_button.style(style::SelectedDefaultButton(color_palette));
-            }
+    match config.wow.flavor {
+        Flavor::Retail => {
+            retail_button = retail_button.style(style::SelectedDefaultButton(color_palette));
+            retail_ptr_button = retail_ptr_button.style(style::DefaultButton(color_palette));
+            retail_beta_button = retail_beta_button.style(style::DefaultButton(color_palette));
+            classic_button = classic_button.style(style::DefaultButton(color_palette));
+            classic_ptr_button = classic_ptr_button.style(style::DefaultButton(color_palette));
+        }
+        Flavor::RetailPTR => {
+            retail_button = retail_button.style(style::DefaultButton(color_palette));
+            retail_ptr_button =
+                retail_ptr_button.style(style::SelectedDefaultButton(color_palette));
+            retail_beta_button = retail_beta_button.style(style::DefaultButton(color_palette));
+            classic_button = classic_button.style(style::DefaultButton(color_palette));
+            classic_ptr_button = classic_ptr_button.style(style::DefaultButton(color_palette));
+        }
+        Flavor::RetailBeta => {
+            retail_button = retail_button.style(style::DefaultButton(color_palette));
+            retail_ptr_button = retail_ptr_button.style(style::DefaultButton(color_palette));
+            retail_beta_button =
+                retail_beta_button.style(style::SelectedDefaultButton(color_palette));
+            classic_button = classic_button.style(style::DefaultButton(color_palette));
+            classic_ptr_button = classic_ptr_button.style(style::DefaultButton(color_palette));
+        }
+        Flavor::Classic => {
+            retail_button = retail_button.style(style::DefaultButton(color_palette));
+            retail_ptr_button = retail_ptr_button.style(style::DefaultButton(color_palette));
+            retail_beta_button = retail_beta_button.style(style::DefaultButton(color_palette));
+            classic_button = classic_button.style(style::SelectedDefaultButton(color_palette));
+            classic_ptr_button = classic_ptr_button.style(style::DefaultButton(color_palette));
+        }
+        Flavor::ClassicPTR => {
+            retail_button = retail_button.style(style::DefaultButton(color_palette));
+            retail_ptr_button = retail_ptr_button.style(style::DefaultButton(color_palette));
+            retail_beta_button = retail_beta_button.style(style::DefaultButton(color_palette));
+            classic_button = classic_button.style(style::DefaultButton(color_palette));
+            classic_ptr_button =
+                classic_ptr_button.style(style::SelectedDefaultButton(color_palette));
         }
     }
 

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -1397,8 +1397,10 @@ pub fn menu_container<'a>(
     let flavor = config.wow.flavor;
 
     // State.
-    let default = &State::default();
-    let myaddons_state = state.get(&Mode::MyAddons(flavor)).unwrap_or(default);
+    let myaddons_state = state
+        .get(&Mode::MyAddons(flavor))
+        .cloned()
+        .unwrap_or_default();
 
     // A row contain general settings.
     let mut settings_row = Row::new().height(Length::Units(50));

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -33,28 +33,33 @@ use widgets::header;
 use element::{DEFAULT_FONT_SIZE, DEFAULT_PADDING};
 static WINDOW_ICON: &[u8] = include_bytes!("../../resources/windows/ajour.ico");
 
-#[derive(Debug)]
-pub enum AjourState {
-    Error(ClientError),
-    Idle,
+#[derive(Debug, Clone, PartialEq)]
+pub enum State {
+    Start,
+    Ready,
     Loading,
-    Welcome,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub enum AjourMode {
+impl Default for State {
+    fn default() -> Self {
+        State::Start
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Mode {
     MyAddons,
     Catalog,
 }
 
-impl std::fmt::Display for AjourMode {
+impl std::fmt::Display for Mode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "{}",
             match self {
-                AjourMode::MyAddons => "My Addons",
-                AjourMode::Catalog => "Catalog",
+                Mode::MyAddons => "My Addons",
+                Mode::Catalog => "Catalog",
             }
         )
     }
@@ -76,7 +81,7 @@ pub enum Interaction {
     SortColumn(ColumnKey),
     SortCatalogColumn(CatalogColumnKey),
     FlavorSelected(Flavor),
-    ResizeColumn(AjourMode, header::ResizeEvent),
+    ResizeColumn(Mode, header::ResizeEvent),
     ScaleUp,
     ScaleDown,
     Backup,
@@ -86,7 +91,7 @@ pub enum Interaction {
     MoveColumnRight(ColumnKey),
     MoveCatalogColumnLeft(CatalogColumnKey),
     MoveCatalogColumnRight(CatalogColumnKey),
-    ModeSelected(AjourMode),
+    ModeSelected(Mode),
     CatalogQuery(String),
     CatalogInstall(catalog::Source, Flavor, u32),
     CatalogCategorySelected(CatalogCategory),
@@ -122,6 +127,9 @@ pub enum Message {
 }
 
 pub struct Ajour {
+    state: HashMap<Mode, State>,
+    error: Option<String>,
+    mode: Mode,
     addons: HashMap<Flavor, Vec<Addon>>,
     addons_scrollable_state: scrollable::State,
     config: Config,
@@ -133,8 +141,6 @@ pub struct Ajour {
     refresh_btn_state: button::State,
     settings_btn_state: button::State,
     shared_client: Arc<HttpClient>,
-    state: AjourState,
-    mode: AjourMode,
     update_all_btn_state: button::State,
     header_state: HeaderState,
     theme_state: ThemeState,
@@ -160,6 +166,15 @@ pub struct Ajour {
 impl Default for Ajour {
     fn default() -> Self {
         Self {
+            state: [
+                (Mode::MyAddons, State::Loading),
+                (Mode::Catalog, State::Loading),
+            ]
+            .iter()
+            .cloned()
+            .collect(),
+            error: None,
+            mode: Mode::MyAddons,
             addons: HashMap::new(),
             addons_scrollable_state: Default::default(),
             config: Config::default(),
@@ -177,8 +192,6 @@ impl Default for Ajour {
                     .build()
                     .unwrap(),
             ),
-            state: AjourState::Loading,
-            mode: AjourMode::MyAddons,
             update_all_btn_state: Default::default(),
             header_state: Default::default(),
             theme_state: Default::default(),
@@ -268,6 +281,7 @@ impl Application for Ajour {
             color_palette,
             &self.mode,
             &self.state,
+            &self.error,
             &self.config,
             &self.valid_flavors,
             &mut self.settings_btn_state,
@@ -315,7 +329,7 @@ impl Application for Ajour {
         content = content.push(Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING)));
 
         match self.mode {
-            AjourMode::MyAddons => {
+            Mode::MyAddons => {
                 // Get mutable addons for current flavor.
                 let addons = self.addons.entry(flavor).or_default();
 
@@ -395,7 +409,7 @@ impl Application for Ajour {
                         .push(bottom_space)
                 }
             }
-            AjourMode::Catalog => {
+            Mode::Catalog => {
                 if let Some(catalog) = &self.catalog {
                     let default = vec![];
                     let addons = self.addons.get(&flavor).unwrap_or(&default);
@@ -544,44 +558,54 @@ impl Application for Ajour {
             }
         }
 
-        // Status messages.
-        let container: Option<Container<Message>> = match self.state {
-            AjourState::Welcome => Some(element::status_container(
-                color_palette,
-                "Welcome to Ajour!",
-                "Please select your World of Warcraft directory",
-                Some(&mut self.onboarding_directory_btn_state),
-            )),
-            AjourState::Idle => match self.mode {
-                AjourMode::MyAddons => {
-                    if !has_addons {
-                        Some(element::status_container(
-                            color_palette,
-                            "Woops!",
-                            &format!("You have no {} addons.", flavor.to_string().to_lowercase()),
-                            None,
-                        ))
-                    } else {
-                        None
+        let container: Option<Container<Message>> = match self.mode {
+            Mode::MyAddons => {
+                let default = &State::default();
+                let state = self.state.get(&Mode::MyAddons).unwrap_or(default);
+                match state {
+                    State::Start => Some(element::status_container(
+                        color_palette,
+                        "Welcome to Ajour!",
+                        "Please select your World of Warcraft directory",
+                        Some(&mut self.onboarding_directory_btn_state),
+                    )),
+                    State::Loading => Some(element::status_container(
+                        color_palette,
+                        "Loading..",
+                        "Currently parsing addons.",
+                        None,
+                    )),
+                    State::Ready => {
+                        if !has_addons {
+                            Some(element::status_container(
+                                color_palette,
+                                "Woops!",
+                                &format!(
+                                    "You have no {} addons.",
+                                    flavor.to_string().to_lowercase()
+                                ),
+                                None,
+                            ))
+                        } else {
+                            None
+                        }
                     }
                 }
-                AjourMode::Catalog => None,
-            },
-            AjourState::Loading => match self.mode {
-                AjourMode::MyAddons => Some(element::status_container(
-                    color_palette,
-                    "Loading..",
-                    "Currently parsing addons.",
-                    None,
-                )),
-                AjourMode::Catalog => Some(element::status_container(
-                    color_palette,
-                    "Loading..",
-                    "Currently loading addon catalog.",
-                    None,
-                )),
-            },
-            _ => None,
+            }
+            Mode::Catalog => {
+                let default = &State::default();
+                let state = self.state.get(&Mode::Catalog).unwrap_or(default);
+                match state {
+                    State::Start => None,
+                    State::Loading => Some(element::status_container(
+                        color_palette,
+                        "Loading..",
+                        "Currently loading catalog.",
+                        None,
+                    )),
+                    State::Ready => None,
+                }
+            }
         };
 
         if let Some(c) = container {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -323,7 +323,7 @@ impl Application for Ajour {
         content = content.push(Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING)));
 
         match self.mode {
-            Mode::MyAddons(_) => {
+            Mode::MyAddons(flavor) => {
                 // Get mutable addons for current flavor.
                 let addons = self.addons.entry(flavor).or_default();
 
@@ -554,7 +554,7 @@ impl Application for Ajour {
         }
 
         let container: Option<Container<Message>> = match self.mode {
-            Mode::MyAddons(_) => {
+            Mode::MyAddons(flavor) => {
                 let default = &State::default();
                 let state = self.state.get(&Mode::MyAddons(flavor)).unwrap_or(default);
                 match state {

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -400,6 +400,11 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             ajour.config.wow.flavor = flavor;
             // Persist the newly updated config.
             let _ = &ajour.config.save();
+            // Update flavor on MyAddons if thats our current mode.
+            match ajour.mode {
+                Mode::MyAddons(_) => ajour.mode = Mode::MyAddons(flavor),
+                _ => (),
+            }
             // Update catalog
             query_and_sort_catalog(ajour);
         }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -401,9 +401,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             // Persist the newly updated config.
             let _ = &ajour.config.save();
             // Update flavor on MyAddons if thats our current mode.
-            match ajour.mode {
-                Mode::MyAddons(_) => ajour.mode = Mode::MyAddons(flavor),
-                _ => (),
+            if let Mode::MyAddons(_) = ajour.mode {
+                ajour.mode = Mode::MyAddons(flavor)
             }
             // Update catalog
             query_and_sort_catalog(ajour);


### PR DESCRIPTION
Resolves multiple problems related to the fact that we had a single `AjourState` enum controlling loading state for multiple areas in the app.

## Proposed Changes
  - Idea is to split it into a `HashMap<Mode, State>` so each mode have its own state.
  - `Mode:MyAddon` now takes `flavor` we each `flavor` also has a `State`.
  - Error is removed from `State` and is now living on the `Ajour` enum.
  
I am missing a few things still, one thing I would like to tackle is how to properly handling multiple flavors loading.

## Checklist

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
