### PR TITLE
chore: version compare

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ dependencies = [
  "opener",
  "structopt",
  "timeago",
+ "version-compare",
  "widgets",
  "winapi 0.3.9",
 ]
@@ -3672,6 +3673,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version-compare"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c18c859eead79d8b95d09e4678566e8d70105c4e7b251f707a03df32442661b"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ log-panics = { version = "2.0", features=['with-backtrace'] }
 structopt = "0.3"
 num-format = "0.4.0"
 futures = "0.3"
+version-compare = "0.0.11"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -20,6 +20,7 @@ use {
         HorizontalAlignment, Length, PickList, Row, Scrollable, Space, Text, VerticalAlignment,
     },
     num_format::{Locale, ToFormattedString},
+    version_compare::{CompOp, VersionCompare},
     widgets::{header, Header},
 };
 
@@ -1569,7 +1570,7 @@ pub fn menu_container<'a>(
         .style(style::NormalErrorForegroundContainer(color_palette));
 
     let version_text = Text::new(if let Some(release) = &self_update_state.latest_release {
-        if release.tag_name != VERSION {
+        if VersionCompare::compare_to(&release.tag_name, VERSION, &CompOp::Gt).unwrap_or(false) {
             needs_update = true;
 
             format!(


### PR DESCRIPTION
Currently if you are running version `0.5.0` and latest release is `0.4.4` Ajour will tell you to "update" to `0.4.4` because the logic for this check is just `!=`. I have changed that and is now using a crate which handles multiple different version systems. Reason for pulling this in is that it could also be useful going forward with Github/Gitlab sources.

## Checklist

- [X] Tested on all platforms changed
