### PR TITLE
chore: update title regex

### DIFF
--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -1101,7 +1101,7 @@ pub fn parse_toc_path(toc_path: &PathBuf) -> Option<AddonFolder> {
 
     // TODO: We should save these somewere so we don't keep creating them.
     let re_toc = regex::Regex::new(r"^##\s*(?P<key>.*?)\s*:\s?(?P<value>.*)").unwrap();
-    let re_title = regex::Regex::new(r"\|[a-fA-F\d]{9}([^|]+)\|?r?|\.?\|T[^|]*\|t").unwrap();
+    let re_title = regex::Regex::new(r"\|(?:[a-fA-F\d]{9}|T[^|]*\|?|t|r)").unwrap();
 
     for line in reader.lines().filter_map(|l| l.ok()) {
         for cap in re_toc.captures_iter(line.as_str()) {


### PR DESCRIPTION
Partial fixes #326.

## Proposed Changes
- Updated the regex for parsing toc titles.
- Refactored so we now use `lazy_static` to avoid compiling the same regexes multiple times
- Added tests
