### PR TITLE
feat: interface fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 ### Added
 - WoWInterface addons has been added to the Catalog.
 
+### Fixed
+- If we don't get Game Version from API we fallback to the one in the TOC file if present.
+
 ## [0.5.0] - 2020-11-03
 
 ### Packaging

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -117,6 +117,7 @@ pub struct AddonFolder {
     /// ID is always the folder name
     pub id: String,
     pub title: String,
+    pub interface: Option<String>,
     pub path: PathBuf,
     pub author: Option<String>,
     pub notes: Option<String>,
@@ -151,6 +152,7 @@ impl AddonFolder {
     pub fn new(
         id: String,
         title: String,
+        interface: Option<String>,
         path: PathBuf,
         author: Option<String>,
         notes: Option<String>,
@@ -161,6 +163,7 @@ impl AddonFolder {
         AddonFolder {
             id,
             title,
+            interface,
             path,
             author,
             notes,
@@ -662,7 +665,15 @@ impl Addon {
 
     /// Returns the game version of the addon.
     pub fn game_version(&self) -> Option<&str> {
-        self.repository_metadata.game_version.as_deref()
+        if self.repository_metadata.game_version.is_some() {
+            self.repository_metadata.game_version.as_deref()
+        } else {
+            self.folders
+                .iter()
+                .find(|f| f.id == self.primary_folder_id)
+                .map(|f| f.interface.as_deref())
+                .flatten()
+        }
     }
 
     /// Returns the notes of the addon.

--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -58,7 +58,7 @@ impl std::fmt::Display for Source {
         let s = match self {
             Source::Curse => "Curse",
             Source::Tukui => "Tukui",
-            Source::WowI => "WowI",
+            Source::WowI => "WowInterface",
         };
         write!(f, "{}", s)
     }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1066,8 +1066,8 @@ impl Default for CatalogHeaderState {
                 CatalogColumnState {
                     key: CatalogColumnKey::Source,
                     btn_state: Default::default(),
-                    width: Length::Units(85),
-                    hidden: false,
+                    width: Length::Units(110),
+                    hidden: true,
                     order: 2,
                 },
                 CatalogColumnState {


### PR DESCRIPTION
Fixes #336

## Proposed Changes
  - If we don't get `game_version` from API, we will fallback to using a parsed `Interface` value from the TOC file.

## Checklist

- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
