### PR TITLE
Feat/catalog refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 ### Added
 - WoWInterface addons has been added to the Catalog.
+- Catalog will automatically refresh if Ajour is kept open.
+  - Underlying catalog data refreshes every night at 00:00 UTC, this refresh triggers at 00:05 UTC
 
 ### Fixed
 - If we don't get Game Version from API we fallback to the one in the TOC file if present.

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -254,7 +254,7 @@ impl Application for Ajour {
     fn subscription(&self) -> Subscription<Self::Message> {
         let runtime_subscription = iced_native::subscription::events().map(Message::RuntimeEvent);
         let catalog_subscription =
-            iced_futures::time::every(Duration::from_secs(5)).map(Message::RefreshCatalog);
+            iced_futures::time::every(Duration::from_secs(60 * 5)).map(Message::RefreshCatalog);
 
         iced::Subscription::batch(vec![runtime_subscription, catalog_subscription])
     }


### PR DESCRIPTION
## Proposed Changes
  - Refresh the catalog if Ajour remains open at 00:05:00 UTC

## Checklist

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
