### PR TITLE
chore: handle todos

### DIFF
--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -102,7 +102,6 @@ mod date_parser {
     where
         D: Deserializer<'de>,
     {
-        // TODO: Theres room for improvements here.
         let s = String::deserialize(deserializer)?;
 
         // Curse format

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -1373,9 +1373,6 @@ pub fn menu_addons_container<'a>(
         .iter()
         .any(|a| matches!(a.state, AddonState::Downloading | AddonState::Unpacking));
 
-    // TODO: Fix
-    let ajour_performing_actions = matches!(state, State::Loading);
-
     // Is any addon updtable.
     let any_addon_updatable = addons
         .iter()
@@ -1391,8 +1388,8 @@ pub fn menu_addons_container<'a>(
 
     // Enable refresh_button if:
     //   - No addon is performing any task.
-    //   - Ajour isn't loading
-    if !addons_performing_actions && !ajour_performing_actions && !matches!(state, State::Start) {
+    //   - Mode state isn't start or loading
+    if !addons_performing_actions && !matches!(state, State::Start | State::Loading) {
         refresh_button = refresh_button.on_press(Interaction::Refresh);
     }
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -536,7 +536,7 @@ impl Application for Ajour {
                     let install_addons = self.catalog_install_addons.entry(flavor).or_default();
 
                     for addon in self.catalog_search_state.catalog_rows.iter_mut() {
-                        // TODO: We should make this prettier with new sources coming in.
+                        // TODO (tarkah): We should make this prettier with new sources coming in.
                         let installed_for_flavor = addons.iter().any(|a| {
                             a.curse_id() == Some(addon.addon.id)
                                 || a.tukui_id() == Some(&addon.addon.id.to_string())


### PR DESCRIPTION
Just a small cleanup PR to fix some of the TODOs we had.
Going forward I would like to a be a little more strict on our `TODOs` and comments in general.

We should follow:

```
// TODO (casperstorm): This is a todo with some information.
```

Or combined with a relevant source:

```
// TODO (casperstorm): Currently we have a problem, but should be fixed eventually.
// @see https://getajour.com
```