### PR TITLE
fix: game version fallback to toc could in some cases fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` and `Removed`.
 
 ## [Unreleased]
+
+## Fixed
+- Game Version fallback to TOC could in some cases fail
+
 ## [0.5.1] - 2020-11-12
 
 ### Added

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -308,6 +308,7 @@ impl Addon {
             .metadata()
             .map(|m| m.game_version.as_deref())
             .flatten()
+            .filter(|s| !s.is_empty())
             .is_some()
         {
             self.metadata().map(|m| m.game_version.as_deref()).flatten()


### PR DESCRIPTION
## Proposed Changes
  - We didn't correctly filter away the empty strings from API which meant we would never fallback to TOC.

## Checklist

- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
