### PR TITLE
feat: hide ignored addons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` and `Removed`.
 
 ## [Unreleased]
+
+### Added
+- Option to hide ignored addons.
+
 ## [0.5.1] - 2020-11-12
 
 ### Added

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -36,6 +36,9 @@ pub struct Config {
 
     #[serde(default)]
     pub backup_wtf: bool,
+
+    #[serde(default)]
+    pub hide_ignored_addons: bool,
 }
 
 impl Config {

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -473,6 +473,26 @@ pub fn settings_container<'a, 'b>(
         (columns_title_row, columns_scrollable)
     };
 
+    let (addons_column, addons_title) = {
+        let addons_title = Text::new("Addons").size(14);
+        let addons_title_row = Row::new().push(addons_title);
+
+        let mut column = Column::new();
+
+        let hide_ignored_addons = config.hide_ignored_addons;
+        let title = "Hide ignored Addons".to_owned();
+        let checkbox = Checkbox::new(hide_ignored_addons, title.clone(), move |is_checked| {
+            Message::Interaction(Interaction::ToggleHideIgnoredAddons(is_checked))
+        })
+        .style(style::DefaultCheckbox(color_palette))
+        .text_size(DEFAULT_FONT_SIZE)
+        .spacing(5);
+
+        column = column.push(checkbox);
+
+        (column, addons_title_row)
+    };
+
     let (website_button, website_title) = {
         let website_info = Text::new("About").size(14);
         let website_info_row = Row::new().push(website_info);
@@ -506,6 +526,10 @@ pub fn settings_container<'a, 'b>(
         .push(backup_now_row)
         .push(Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING)))
         .push(backup_directory_row)
+        .push(Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING)))
+        .push(addons_title)
+        .push(Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING)))
+        .push(addons_column)
         .push(bottom_space);
 
     let middle_column = Column::new()

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -573,7 +573,7 @@ pub fn settings_container<'a, 'b>(
         .style(style::BrightForegroundContainer(color_palette));
 
     let install_from_url_option_column = Column::new()
-        .push(Text::new("Install From URL Options").size(DEFAULT_FONT_SIZE))
+        .push(Text::new("Install from URL Options").size(DEFAULT_FONT_SIZE))
         .push(Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING)))
         .push(
             Container::new(Text::new("No options").size(DEFAULT_FONT_SIZE))
@@ -1530,7 +1530,7 @@ pub fn menu_container<'a>(
 
     let mut install_mode_button = Button::new(
         install_mode_btn_state,
-        Text::new("Install From URL").size(DEFAULT_FONT_SIZE),
+        Text::new("Install from URL").size(DEFAULT_FONT_SIZE),
     )
     .style(style::DisabledDefaultButton(color_palette));
 

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -481,7 +481,7 @@ pub fn settings_container<'a, 'b>(
 
         let hide_ignored_addons = config.hide_ignored_addons;
         let title = "Hide ignored Addons".to_owned();
-        let checkbox = Checkbox::new(hide_ignored_addons, title.clone(), move |is_checked| {
+        let checkbox = Checkbox::new(hide_ignored_addons, title, move |is_checked| {
             Message::Interaction(Interaction::ToggleHideIgnoredAddons(is_checked))
         })
         .style(style::DefaultCheckbox(color_palette))

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -4,7 +4,7 @@ mod update;
 
 use crate::cli::Opts;
 use ajour_core::{
-    addon::{Addon, AddonFolder, AddonVersionKey},
+    addon::{Addon, AddonFolder, AddonState, AddonVersionKey},
     cache::{
         load_addon_cache, load_fingerprint_cache, AddonCache, AddonCacheEntry, FingerprintCache,
     },
@@ -95,6 +95,7 @@ pub enum Interaction {
     Backup,
     ToggleColumn(bool, ColumnKey),
     ToggleCatalogColumn(bool, CatalogColumnKey),
+    ToggleHideIgnoredAddons(bool),
     MoveColumnLeft(ColumnKey),
     MoveColumnRight(ColumnKey),
     MoveCatalogColumnLeft(CatalogColumnKey),
@@ -393,6 +394,10 @@ impl Application for Ajour {
 
                 // Loops though the addons.
                 for addon in addons {
+                    if addon.state == AddonState::Ignored {
+                        // println!("we have ignored: {:?}", addon.title());
+                    }
+
                     // Checks if the current addon is expanded.
                     let is_addon_expanded = match &self.expanded_type {
                         ExpandType::Details(a) => a.primary_folder_id == addon.primary_folder_id,

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -394,8 +394,9 @@ impl Application for Ajour {
 
                 // Loops though the addons.
                 for addon in addons {
-                    if addon.state == AddonState::Ignored {
-                        // println!("we have ignored: {:?}", addon.title());
+                    // If hiding ignored addons, we will skip it.
+                    if addon.state == AddonState::Ignored && self.config.hide_ignored_addons {
+                        break;
                     }
 
                     // Checks if the current addon is expanded.

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -396,7 +396,7 @@ impl Application for Ajour {
                 for addon in addons {
                     // If hiding ignored addons, we will skip it.
                     if addon.state == AddonState::Ignored && self.config.hide_ignored_addons {
-                        break;
+                        continue;
                     }
 
                     // Checks if the current addon is expanded.

--- a/src/gui/style.rs
+++ b/src/gui/style.rs
@@ -586,8 +586,8 @@ impl checkbox::StyleSheet for DefaultCheckbox {
         checkbox::Style {
             background: Background::Color(self.0.base.foreground),
             checkmark_color: self.0.bright.primary,
-            border_radius: 3,
-            border_width: 2,
+            border_radius: 2,
+            border_width: 1,
             border_color: self.0.normal.primary,
         }
     }
@@ -596,7 +596,7 @@ impl checkbox::StyleSheet for DefaultCheckbox {
         checkbox::Style {
             background: Background::Color(self.0.base.foreground),
             checkmark_color: self.0.bright.primary,
-            border_radius: 3,
+            border_radius: 2,
             border_width: 2,
             border_color: self.0.bright.primary,
         }
@@ -609,8 +609,8 @@ impl checkbox::StyleSheet for AlwaysCheckedCheckbox {
         checkbox::Style {
             background: Background::Color(self.0.base.foreground),
             checkmark_color: self.0.normal.primary,
-            border_radius: 3,
-            border_width: 2,
+            border_radius: 2,
+            border_width: 1,
             border_color: self.0.normal.primary,
         }
     }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1469,6 +1469,12 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 }
             }
         }
+        Message::Interaction(Interaction::ToggleHideIgnoredAddons(is_checked)) => {
+            log::debug!("Interaction::ToggleHideIgnoredAddons({})", is_checked);
+
+            ajour.config.hide_ignored_addons = is_checked;
+            let _ = ajour.config.save();
+        }
         Message::Error(error)
         | Message::CatalogDownloaded(Err(error))
         | Message::AddonCacheUpdated(Err(error)) => {


### PR DESCRIPTION
## Proposed Changes
  - Added a option to hide ignored addons.

## Checklist

- [x] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
