### PR TITLE
Catalog date order on first click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 - Game Version fallback to TOC could in some cases fail
 - Load addons into catalog asynchronously
 - Only show categories pertaining to the source selected
+- Date sort catalog descending first, which is more natural
 
 ## [0.5.1] - 2020-11-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,16 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 ### Packaging
 - Updated Ajour icon on macOS to a "Big Sur" version 
 
-## Added
+### Added
 - Option to hide ignored addons
+
+### Changed
+- Date sort catalog descending first, which is more natural
 
 ### Fixed
 - Game Version fallback to TOC could in some cases fail
 - Load addons into catalog asynchronously
 - Only show categories pertaining to the source selected
-- Date sort catalog descending first, which is more natural
 
 ## [0.5.1] - 2020-11-12
 

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -788,6 +788,12 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             {
                 sort_direction = SortDirection::Desc;
             }
+            // Exception for the date released
+            if ajour.catalog_header_state.previous_column_key.is_none()
+                && column_key == CatalogColumnKey::DateReleased
+            {
+                sort_direction = SortDirection::Desc;
+            }
 
             log::debug!(
                 "Interaction::SortCatalogColumn({:?}, {:?})",


### PR DESCRIPTION
Makes it so, in the catalog, if you click on 'date released', it sorts descending by default.

I believe that’s what 99.9 % of users expect.

## Checklist

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
