### PR TITLE
Fix/null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bug that caused catalog to fail downloading when `null` values existed
+  in the payload
+
 ## [0.5.2] - 2020-11-20
 
 ### Packaging

--- a/crates/core/src/catalog.rs
+++ b/crates/core/src/catalog.rs
@@ -94,6 +94,7 @@ pub struct Catalog {
 #[serde(rename_all = "camelCase")]
 #[derive(Debug, Clone, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct GameVersion {
+    #[serde(with = "null_to_default")]
     pub game_version: String,
     pub flavor: Flavor,
 }
@@ -101,18 +102,39 @@ pub struct GameVersion {
 #[serde(rename_all = "camelCase")]
 #[derive(Debug, Clone, Deserialize)]
 pub struct CatalogAddon {
+    #[serde(with = "null_to_default")]
     pub id: i32,
+    #[serde(with = "null_to_default")]
     pub website_url: String,
     #[serde(with = "date_parser")]
     pub date_released: Option<DateTime<Utc>>,
+    #[serde(with = "null_to_default")]
     pub name: String,
+    #[serde(with = "null_to_default")]
     pub categories: Vec<String>,
+    #[serde(with = "null_to_default")]
     pub summary: String,
+    #[serde(with = "null_to_default")]
     pub number_of_downloads: u64,
     pub source: Source,
+    #[serde(with = "null_to_default")]
     #[deprecated(since = "0.4.4", note = "Please use game_versions instead")]
     pub flavors: Vec<Flavor>,
+    #[serde(with = "null_to_default")]
     pub game_versions: Vec<GameVersion>,
+}
+
+mod null_to_default {
+    use serde::{self, Deserialize, Deserializer};
+
+    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: Default + Deserialize<'de>,
+    {
+        let opt = Option::deserialize(deserializer)?;
+        Ok(opt.unwrap_or_default())
+    }
 }
 
 mod date_parser {
@@ -176,5 +198,17 @@ mod tests {
                 panic!("{}", e);
             }
         });
+    }
+
+    #[test]
+    fn test_null_fields() {
+        let tests = [
+            r"[]",
+            r#"[{"id": null,"websiteUrl": null,"dateReleased":"2020-11-20T02:29:43.46Z","name": null,"summary": null,"numberOfDownloads": null,"categories": null,"flavors": null,"gameVersions": null,"source":"curse"}]"#,
+        ];
+
+        for test in tests.iter() {
+            serde_json::from_str::<Vec<CatalogAddon>>(test).unwrap();
+        }
     }
 }


### PR DESCRIPTION
Resolves issue discussed in discord

## Proposed Changes
  - Add a custom deserializer to deser null as Default. This way we don't need to  specify our fields as `Option<T>`.
  - Added a new test to validate this works

## Checklist

- [ ] Tested on Windows
- [x] Tested on MacOS
- [x] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
