### PR TITLE
add backup via cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Added
+
+- Added an option to Backup via the command line. Flavors and backup folder sources
+  can be specified.
+  - Pass `ajour backup --help` to get help using this new command.
+
 ## [0.5.2] - 2020-11-20
 
 ### Packaging

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,6 +93,18 @@ pub enum Command {
         /// source url [Github & Gitlab currently supported]
         url: Uri,
     },
+    /// Backup your WTF and/or AddOns folders
+    Backup {
+        #[structopt(short, long, default_value = "both", parse(try_from_str = str_to_backup_folder), possible_values = &["both","wtf","addons"])]
+        /// folder to backup
+        backup_folder: BackupFolder,
+        #[structopt(short, long, parse(try_from_str = str_to_flavor), possible_values = &["retail","ptr","beta","classic","classic_ptr"])]
+        /// space separated list of flavors to include in backup. If ommited, all flavors will be included.
+        flavors: Vec<Flavor>,
+        #[structopt()]
+        /// folder to save backups to
+        destination: PathBuf,
+    },
 }
 
 fn str_to_flavor(s: &str) -> Result<Flavor, &'static str> {
@@ -103,5 +115,21 @@ fn str_to_flavor(s: &str) -> Result<Flavor, &'static str> {
         "classic" => Ok(Flavor::Classic),
         "classic_ptr" => Ok(Flavor::ClassicPTR),
         _ => Err("valid values are ['retail','ptr','beta','classic','classic_ptr']"),
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum BackupFolder {
+    Both,
+    AddOns,
+    WTF,
+}
+
+fn str_to_backup_folder(s: &str) -> Result<BackupFolder, &'static str> {
+    match s {
+        "both" => Ok(BackupFolder::Both),
+        "wtf" => Ok(BackupFolder::WTF),
+        "addons" => Ok(BackupFolder::AddOns),
+        _ => Err("valid values are ['both','wtf','addons']"),
     }
 }

--- a/src/command/backup.rs
+++ b/src/command/backup.rs
@@ -1,0 +1,72 @@
+use crate::cli::BackupFolder;
+
+use ajour_core::backup::{self, backup_folders};
+use ajour_core::config::{load_config, Flavor};
+use ajour_core::{error, Result};
+
+use async_std::task;
+use std::path::PathBuf;
+
+pub fn backup(
+    backup_folder: BackupFolder,
+    destination: PathBuf,
+    flavors: Vec<Flavor>,
+) -> Result<()> {
+    task::block_on(async {
+        let config = load_config().await?;
+
+        let flavors = if flavors.is_empty() {
+            Flavor::ALL.to_vec()
+        } else {
+            flavors
+        };
+
+        if !destination.is_dir() {
+            return Err(error!("destination must be a folder, not a file"));
+        }
+
+        let wow_dir = config.wow.directory.as_ref().ok_or_else(|| error!("No WoW directory set. Launch Ajour and make sure a WoW directory is set before using the command line."))?;
+
+        log::info!(
+            "Backing up:\n\tbackup folders: {:?}\n\tflavors: {:?}\n\tdestination: {:?}",
+            backup_folder,
+            flavors,
+            destination
+        );
+
+        let mut src_folders = vec![];
+
+        for flavor in flavors {
+            let addon_directory = config.get_addon_directory_for_flavor(&flavor).ok_or_else(|| error!("No WoW directory set. Launch Ajour and make sure a WoW directory is set before using the command line."))?;
+            let wtf_directory = config.get_wtf_directory_for_flavor(&flavor).ok_or_else(|| error!("No WoW directory set. Launch Ajour and make sure a WoW directory is set before using the command line."))?;
+
+            let addons_folder = backup::BackupFolder::new(&addon_directory, &wow_dir);
+            let wtf_folder = backup::BackupFolder::new(&wtf_directory, &wow_dir);
+
+            match backup_folder {
+                BackupFolder::Both => {
+                    if addon_directory.exists() && wtf_directory.exists() {
+                        src_folders.push(addons_folder);
+                        src_folders.push(wtf_folder);
+                    }
+                }
+                BackupFolder::AddOns => {
+                    if addon_directory.exists() {
+                        src_folders.push(addons_folder);
+                    }
+                }
+                BackupFolder::WTF => {
+                    if wtf_directory.exists() {
+                        src_folders.push(wtf_folder);
+                    }
+                }
+            }
+        }
+
+        backup_folders(src_folders, destination).await?;
+
+        log::info!("Backup complete!");
+
+        Ok(())
+    })
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,3 +1,6 @@
+mod backup;
+pub use backup::backup;
+
 mod install;
 pub use install::install_from_source;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,11 @@ pub fn main() {
         Some(command) => {
             // Process the command and exit
             if let Err(e) = match command {
+                cli::Command::Backup {
+                    backup_folder,
+                    destination,
+                    flavors,
+                } => command::backup(backup_folder, destination, flavors),
                 cli::Command::Update => command::update_all_addons(),
                 cli::Command::Install { url, flavor } => command::install_from_source(url, flavor),
             } {


### PR DESCRIPTION
Resolves feature requested in discord

## Proposed Changes
  - add option to backup folders via command line
  - flavors and backup folders can be specified 

## Checklist

- [ ] Tested on Windows
- [x] Tested on MacOS
- [x] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
