### PR TITLE
chore: refactored AddonState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Added
+
+- Ability to retry if a addon fails during either download or unpacking
+
 ## [0.5.3] - 2020-11-23
 
 ### Added

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -20,10 +20,6 @@ pub enum AddonVersionKey {
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub enum AddonState {
     Completed,
-    // TODO: I have currently removed the state where curse-id only addons become corrupt.
-    // It can happen that the fingerprint is unknown to the API but everything else is good.
-    // This is properly not the best solution going forward, but for now it solves the purpose.
-    Corrupted,
     Downloading,
     Error(String),
     Fingerprint,
@@ -31,6 +27,7 @@ pub enum AddonState {
     Ignored,
     Unknown,
     Unpacking,
+    Retry,
     Updatable,
 }
 

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -19,16 +19,18 @@ pub enum AddonVersionKey {
 
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub enum AddonState {
-    Ignored,
-    Unknown,
-    Ajour(Option<String>),
-    Downloading,
-    Fingerprint,
-    Unpacking,
+    Completed,
     // TODO: I have currently removed the state where curse-id only addons become corrupt.
     // It can happen that the fingerprint is unknown to the API but everything else is good.
     // This is properly not the best solution going forward, but for now it solves the purpose.
     Corrupted,
+    Downloading,
+    Error(String),
+    Fingerprint,
+    Idle,
+    Ignored,
+    Unknown,
+    Unpacking,
     Updatable,
 }
 
@@ -152,7 +154,7 @@ impl Addon {
             primary_folder_id: primary_folder_id.to_string(),
             folders: Default::default(),
             release_channel: Default::default(),
-            state: AddonState::Ajour(None),
+            state: AddonState::Idle,
             repository: Default::default(),
 
             #[cfg(feature = "gui")]

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -1061,14 +1061,28 @@ pub fn addon_data_cell<'a, 'b>(
         .next()
     {
         let update_button_container = match &addon.state {
-            AddonState::Ajour(string) => Container::new(
-                Text::new(string.clone().unwrap_or_else(|| "".to_string())).size(DEFAULT_FONT_SIZE),
-            )
-            .height(default_height)
-            .width(*width)
-            .center_y()
-            .center_x()
-            .style(style::NormalForegroundContainer(color_palette)),
+            AddonState::Idle => Container::new(Text::new("".to_string()).size(DEFAULT_FONT_SIZE))
+                .height(default_height)
+                .width(*width)
+                .center_y()
+                .center_x()
+                .style(style::NormalForegroundContainer(color_palette)),
+            AddonState::Completed => {
+                Container::new(Text::new("Completed".to_string()).size(DEFAULT_FONT_SIZE))
+                    .height(default_height)
+                    .width(*width)
+                    .center_y()
+                    .center_x()
+                    .style(style::NormalForegroundContainer(color_palette))
+            }
+            AddonState::Error(message) => {
+                Container::new(Text::new(message).size(DEFAULT_FONT_SIZE))
+                    .height(default_height)
+                    .width(*width)
+                    .center_y()
+                    .center_x()
+                    .style(style::NormalForegroundContainer(color_palette))
+            }
             AddonState::Updatable | AddonState::Corrupted => {
                 let id = addon.primary_folder_id.clone();
                 let text = if addon.state == AddonState::Updatable {

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -1083,12 +1083,13 @@ pub fn addon_data_cell<'a, 'b>(
                     .center_x()
                     .style(style::NormalForegroundContainer(color_palette))
             }
-            AddonState::Updatable | AddonState::Corrupted => {
+            AddonState::Updatable | AddonState::Retry => {
                 let id = addon.primary_folder_id.clone();
-                let text = if addon.state == AddonState::Updatable {
-                    "Update"
-                } else {
-                    "Repair"
+
+                let text = match addon.state {
+                    AddonState::Updatable => "Update",
+                    AddonState::Retry => "Retry",
+                    _ => "",
                 };
 
                 let update_wrapper = Container::new(Text::new(text).size(DEFAULT_FONT_SIZE))

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -457,7 +457,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
 
                             // Check if addon is updatable based on release channel.
                             if let Some(package) = a.relevant_release_package() {
-                                if a.is_updatable(&package) && a.state != AddonState::Corrupted {
+                                if a.is_updatable(&package) {
                                     a.state = AddonState::Updatable;
                                 }
                             }
@@ -524,10 +524,20 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                     log_error(&error);
                     ajour.error = Some(error);
 
-                    if reason == DownloadReason::Install {
-                        if let Some(install_addon) = install_addons.iter_mut().find(|a| a.id == id)
-                        {
-                            install_addon.status = InstallStatus::Retry;
+                    match reason {
+                        DownloadReason::Update => {
+                            if let Some(_addon) =
+                                addons.iter_mut().find(|a| a.primary_folder_id == id)
+                            {
+                                _addon.state = AddonState::Retry;
+                            }
+                        }
+                        DownloadReason::Install => {
+                            if let Some(install_addon) =
+                                install_addons.iter_mut().find(|a| a.id == id)
+                            {
+                                install_addon.status = InstallStatus::Retry;
+                            }
                         }
                     }
                 }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -168,7 +168,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                     if addon.is_updatable(&package) {
                         addon.state = AddonState::Updatable;
                     } else {
-                        addon.state = AddonState::Ajour(None);
+                        addon.state = AddonState::Idle;
                     }
                 }
             };
@@ -693,9 +693,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             let addons = ajour.addons.entry(flavor).or_default();
             if let Some(addon) = addons.iter_mut().find(|a| a.primary_folder_id == id) {
                 if result.is_ok() {
-                    addon.state = AddonState::Ajour(Some("Completed".to_owned()));
+                    addon.state = AddonState::Completed;
                 } else {
-                    addon.state = AddonState::Ajour(Some("Error".to_owned()));
+                    addon.state = AddonState::Error("Error".to_owned());
                 }
             }
         }
@@ -802,7 +802,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                         if addon.is_updatable(&package) {
                             addon.state = AddonState::Updatable;
                         } else {
-                            addon.state = AddonState::Ajour(None);
+                            addon.state = AddonState::Idle;
                         }
                     }
 

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -618,10 +618,20 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                     log_error(&error);
                     ajour.error = Some(error);
 
-                    if reason == DownloadReason::Install {
-                        if let Some(install_addon) = install_addons.iter_mut().find(|a| a.id == id)
-                        {
-                            install_addon.status = InstallStatus::Retry;
+                    match reason {
+                        DownloadReason::Update => {
+                            if let Some(_addon) =
+                                addons.iter_mut().find(|a| a.primary_folder_id == id)
+                            {
+                                _addon.state = AddonState::Retry;
+                            }
+                        }
+                        DownloadReason::Install => {
+                            if let Some(install_addon) =
+                                install_addons.iter_mut().find(|a| a.id == id)
+                            {
+                                install_addon.status = InstallStatus::Retry;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Proposed Changes
  - If download fails on a addon we show a  retry button.

## Checklist

- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
