### PR TITLE
fix: refresh catalog 00:40 instead of 00:05

### DIFF
--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1465,7 +1465,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
             if let Some(last_updated) = &ajour.catalog_last_updated {
                 let now = Utc::now();
                 let now_time = now.time();
-                let refresh_time = NaiveTime::from_hms(0, 5, 0);
+                let refresh_time = NaiveTime::from_hms(0, 40, 0);
 
                 if last_updated.date() < now.date() && now_time > refresh_time {
                     log::debug!("Message::RefreshCatalog: catalog needs to be refreshed");


### PR DESCRIPTION
## Proposed Changes
  - [It seems ](https://github.com/casperstorm/ajour-catalog/releases?after=2020-11-20-00-29) catalog is done 00:3x and not 00:0x. I've updated timer to 00:40.
