### PR TITLE
feat: simplify changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and `Removed`.
 - Ability to retry if a addon fails during either download or unpacking
 - Added a minimum size to Ajour window
 
+### Changed
+
+- A new Changelog button is now found when you expand a addon.
+  - The old Changelog system has been removed which means you can no longer
+  press either local or remote version.
+
 ## [0.5.3] - 2020-11-23
 
 ### Added

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -143,6 +143,8 @@ pub struct Addon {
     pub website_btn_state: iced_native::button::State,
     #[cfg(feature = "gui")]
     pub pick_release_channel_state: iced_native::pick_list::State<ReleaseChannel>,
+    #[cfg(feature = "gui")]
+    pub changelog_btn_state: iced_native::button::State,
 }
 
 impl Addon {
@@ -176,6 +178,8 @@ impl Addon {
             website_btn_state: Default::default(),
             #[cfg(feature = "gui")]
             pick_release_channel_state: Default::default(),
+            #[cfg(feature = "gui")]
+            changelog_btn_state: Default::default(),
         }
     }
 
@@ -333,6 +337,13 @@ impl Addon {
     /// Returns the website url of the addon.
     pub fn website_url(&self) -> Option<&str> {
         self.metadata().map(|m| m.website_url.as_deref()).flatten()
+    }
+
+    /// Returns the changelog url of the addon.
+    pub fn changelog_url(&self) -> Option<&str> {
+        self.metadata()
+            .map(|m| m.changelog_url.as_deref())
+            .flatten()
     }
 
     /// Returns the curse id of the addon, if applicable.

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{ParseError, RepositoryError},
+    error::ParseError,
     repository::{
         ReleaseChannel, RemotePackage, RepositoryIdentifiers, RepositoryKind, RepositoryMetadata,
         RepositoryPackage,
@@ -124,12 +124,6 @@ pub struct Addon {
     #[cfg(feature = "gui")]
     pub details_btn_state: iced_native::button::State,
     #[cfg(feature = "gui")]
-    pub remote_btn_state: iced_native::button::State,
-    #[cfg(feature = "gui")]
-    pub local_btn_state: iced_native::button::State,
-    #[cfg(feature = "gui")]
-    pub full_changelog_btn_state: iced_native::button::State,
-    #[cfg(feature = "gui")]
     pub update_btn_state: iced_native::button::State,
     #[cfg(feature = "gui")]
     pub force_btn_state: iced_native::button::State,
@@ -158,12 +152,6 @@ impl Addon {
 
             #[cfg(feature = "gui")]
             details_btn_state: Default::default(),
-            #[cfg(feature = "gui")]
-            remote_btn_state: Default::default(),
-            #[cfg(feature = "gui")]
-            local_btn_state: Default::default(),
-            #[cfg(feature = "gui")]
-            full_changelog_btn_state: Default::default(),
             #[cfg(feature = "gui")]
             update_btn_state: Default::default(),
             #[cfg(feature = "gui")]

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -508,19 +508,6 @@ impl Addon {
             }
         }
     }
-
-    pub async fn get_changelog(
-        &self,
-        is_remote: bool,
-    ) -> Result<(String, String), RepositoryError> {
-        if let Some(repository) = self.repository() {
-            return repository
-                .get_changelog(self.release_channel, is_remote)
-                .await;
-        }
-
-        Err(RepositoryError::AddonNoRepository)
-    }
 }
 
 impl PartialEq for Addon {

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -481,7 +481,8 @@ async fn get_all_repo_packages(
                 let package = curse_packages.remove(idx);
 
                 r.metadata.title = Some(package.name.clone());
-                r.metadata.website_url = Some(package.website_url);
+                r.metadata.website_url = Some(package.website_url.clone());
+                r.metadata.changelog_url = Some(format!("{}/files", package.website_url));
             }
         });
 

--- a/crates/core/src/repository/backend/curse.rs
+++ b/crates/core/src/repository/backend/curse.rs
@@ -45,34 +45,6 @@ impl Backend for Curse {
         Ok(metadata)
     }
 
-    async fn get_changelog(
-        &self,
-        file_id: Option<i64>,
-        _tag_name: Option<String>,
-    ) -> Result<(String, String), RepositoryError> {
-        let file_id = file_id.ok_or(RepositoryError::CurseChangelogFileId)?;
-
-        let url = format!(
-            "{}/addon/{}/file/{}/changelog",
-            API_ENDPOINT, self.id, file_id
-        );
-        let client = HttpClient::builder().build().unwrap();
-        let mut resp = request_async(&client, &url.clone(), vec![], None).await?;
-
-        if resp.status().is_success() {
-            let changelog: String = resp.text()?;
-
-            let c = regex_html_tags_to_newline()
-                .replace_all(&changelog, "\n")
-                .to_string();
-            let c = regex_html_tags_to_space().replace_all(&c, "").to_string();
-            let c = truncate(&c, 2500).to_string();
-
-            return Ok((c, url));
-        }
-
-        Ok(("No changelog found.".to_owned(), url))
-    }
 }
 
 pub(crate) fn metadata_from_curse_package(flavor: Flavor, package: Package) -> RepositoryMetadata {

--- a/crates/core/src/repository/backend/curse.rs
+++ b/crates/core/src/repository/backend/curse.rs
@@ -114,7 +114,8 @@ pub(crate) fn metadata_from_curse_package(flavor: Flavor, package: Package) -> R
     let mut metadata = RepositoryMetadata::empty();
     metadata.remote_packages = remote_packages;
     metadata.title = Some(package.name.clone());
-    metadata.website_url = Some(package.website_url);
+    metadata.website_url = Some(package.website_url.clone());
+    metadata.changelog_url = Some(format!("{}/files", package.website_url));
 
     metadata
 }

--- a/crates/core/src/repository/backend/curse.rs
+++ b/crates/core/src/repository/backend/curse.rs
@@ -1,9 +1,8 @@
 use super::*;
 use crate::config::Flavor;
 use crate::error::DownloadError;
-use crate::network::{post_json_async, request_async};
+use crate::network::post_json_async;
 use crate::repository::{ReleaseChannel, RemotePackage};
-use crate::utility::{regex_html_tags_to_newline, regex_html_tags_to_space, truncate};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -44,7 +43,6 @@ impl Backend for Curse {
 
         Ok(metadata)
     }
-
 }
 
 pub(crate) fn metadata_from_curse_package(flavor: Flavor, package: Package) -> RepositoryMetadata {

--- a/crates/core/src/repository/backend/git.rs
+++ b/crates/core/src/repository/backend/git.rs
@@ -116,40 +116,6 @@ mod github {
 
             Ok(metadata)
         }
-
-        async fn get_changelog(
-            &self,
-            _file_id: Option<i64>,
-            tag_name: Option<String>,
-        ) -> Result<(String, String), RepositoryError> {
-            let tag_name = tag_name.ok_or(RepositoryError::GitChangelogTagName)?;
-
-            let client = HttpClient::new()?;
-
-            let mut path = self.url.path().split('/');
-            // Get rid of leading slash
-            path.next();
-
-            let author = path.next().ok_or(RepositoryError::GitMissingAuthor {
-                url: self.url.to_string(),
-            })?;
-            let repo = path.next().ok_or(RepositoryError::GitMissingRepo {
-                url: self.url.to_string(),
-            })?;
-
-            let url = format!(
-                "https://api.github.com/repos/{}/{}/releases/tags/{}",
-                author, repo, tag_name
-            );
-
-            let mut resp = request_async(&client, &url, vec![], None).await?;
-
-            let release: Release = resp
-                .json()
-                .map_err(|_| RepositoryError::GitMissingRelease { url })?;
-
-            Ok((release.body, release.html_url))
-        }
     }
 
     #[derive(Debug, Deserialize, Clone)]
@@ -290,42 +256,6 @@ mod gitlab {
             };
 
             Ok(metadata)
-        }
-
-        async fn get_changelog(
-            &self,
-            _file_id: Option<i64>,
-            tag_name: Option<String>,
-        ) -> Result<(String, String), RepositoryError> {
-            let tag_name = tag_name.ok_or(RepositoryError::GitChangelogTagName)?;
-
-            let client = HttpClient::new()?;
-
-            let mut path = self.url.path().split('/');
-            // Get rid of leading slash
-            path.next();
-
-            let author = path.next().ok_or(RepositoryError::GitMissingAuthor {
-                url: self.url.to_string(),
-            })?;
-            let repo = path.next().ok_or(RepositoryError::GitMissingRepo {
-                url: self.url.to_string(),
-            })?;
-
-            let url = format!(
-                "https://gitlab.com/api/v4/projects/{}%2F{}/releases/{}",
-                author, repo, tag_name
-            );
-
-            let mut resp = request_async(&client, &url, vec![], None).await?;
-
-            let release: Release = resp
-                .json()
-                .map_err(|_| RepositoryError::GitMissingRelease { url })?;
-
-            let release_url = format!("https://gitlab.com{}", &release.tag_path);
-
-            Ok((release.description, release_url))
         }
     }
 

--- a/crates/core/src/repository/backend/git.rs
+++ b/crates/core/src/repository/backend/git.rs
@@ -97,7 +97,7 @@ mod github {
 
             let mut remote_packages = HashMap::new();
             let remote_package = RemotePackage {
-                version,
+                version: version.clone(),
                 download_url,
                 date_time,
                 file_id: None,
@@ -108,6 +108,7 @@ mod github {
 
             let metadata = RepositoryMetadata {
                 website_url: Some(self.url.to_string()),
+                changelog_url: Some(format!("{}/releases/tag/{}", self.url, version)),
                 remote_packages,
                 title: Some(repo.to_string()),
                 ..Default::default()
@@ -271,7 +272,7 @@ mod gitlab {
 
             let mut remote_packages = HashMap::new();
             let remote_package = RemotePackage {
-                version,
+                version: version.clone(),
                 download_url,
                 date_time,
                 file_id: None,
@@ -282,6 +283,7 @@ mod gitlab {
 
             let metadata = RepositoryMetadata {
                 website_url: Some(self.url.to_string()),
+                changelog_url: Some(format!("{}/-/tags/{}", self.url, version)),
                 remote_packages,
                 title: Some(repo.to_string()),
                 ..Default::default()

--- a/crates/core/src/repository/backend/mod.rs
+++ b/crates/core/src/repository/backend/mod.rs
@@ -17,12 +17,6 @@ pub use wowi::WowI;
 #[async_trait]
 pub(crate) trait Backend: DynClone + Send + Sync {
     async fn get_metadata(&self) -> Result<RepositoryMetadata, RepositoryError>;
-
-    async fn get_changelog(
-        &self,
-        file_id: Option<i64>,
-        tag_name: Option<String>,
-    ) -> Result<(String, String), RepositoryError>;
 }
 
 clone_trait_object!(Backend);

--- a/crates/core/src/repository/backend/tukui.rs
+++ b/crates/core/src/repository/backend/tukui.rs
@@ -110,11 +110,13 @@ pub(crate) fn metadata_from_tukui_package(package: TukuiPackage) -> RepositoryMe
     }
 
     let website_url = Some(package.web_url.clone());
+    let changelog_url = Some(format!("{}&changelog", package.web_url));
     let game_version = package.patch;
     let title = package.name;
 
     let mut metadata = RepositoryMetadata::empty();
     metadata.website_url = website_url;
+    metadata.changelog_url = changelog_url;
     metadata.game_version = game_version;
     metadata.remote_packages = remote_packages;
     metadata.title = Some(title);

--- a/crates/core/src/repository/backend/tukui.rs
+++ b/crates/core/src/repository/backend/tukui.rs
@@ -102,7 +102,6 @@ fn api_endpoint(id: &str, flavor: &Flavor) -> String {
     )
 }
 
-
 /// Function to fetch a remote addon package which contains
 /// information about the addon on the repository.
 pub(crate) async fn fetch_remote_package(

--- a/crates/core/src/repository/backend/tukui.rs
+++ b/crates/core/src/repository/backend/tukui.rs
@@ -37,46 +37,6 @@ impl Backend for Tukui {
 
         Ok(metadata)
     }
-
-    async fn get_changelog(
-        &self,
-        _file_id: Option<i64>,
-        _tag_name: Option<String>,
-    ) -> Result<(String, String), RepositoryError> {
-        let url = changelog_endpoint(&self.id, &self.flavor);
-
-        match self.flavor {
-            Flavor::Retail | Flavor::RetailBeta | Flavor::RetailPTR => {
-                // Only TukUI and ElvUI main addons has changelog which can be fetched.
-                // The others is embeded into a page.
-                if &self.id == "-1" || &self.id == "-2" {
-                    let client = HttpClient::builder().build().unwrap();
-                    let mut resp = request_async(&client, &url.clone(), vec![], None).await?;
-
-                    if resp.status().is_success() {
-                        let changelog: String = resp.text()?;
-
-                        let c = regex_html_tags_to_newline()
-                            .replace_all(&changelog, "\n")
-                            .to_string();
-                        let c = regex_html_tags_to_space().replace_all(&c, "").to_string();
-                        let c = truncate(&c, 2500).to_string();
-
-                        return Ok((c, url));
-                    }
-
-                    return Ok(("No changelog found".to_string(), url));
-                }
-
-                Ok(("Please view this changelog in the browser by pressing 'Full Changelog' to the right".to_string(), url))
-            }
-            Flavor::Classic | Flavor::ClassicPTR => Ok((
-                "Please view this changelog in the browser by pressing 'Full Changelog' to the right"
-                    .to_string(),
-                url,
-            )),
-        }
-    }
 }
 
 pub(crate) fn metadata_from_tukui_package(package: TukuiPackage) -> RepositoryMetadata {

--- a/crates/core/src/repository/backend/tukui.rs
+++ b/crates/core/src/repository/backend/tukui.rs
@@ -3,7 +3,6 @@ use crate::config::Flavor;
 use crate::error::{DownloadError, RepositoryError};
 use crate::network::request_async;
 use crate::repository::{ReleaseChannel, RemotePackage};
-use crate::utility::{regex_html_tags_to_newline, regex_html_tags_to_space, truncate};
 
 use async_trait::async_trait;
 use chrono::{NaiveDateTime, TimeZone, Utc};
@@ -103,19 +102,6 @@ fn api_endpoint(id: &str, flavor: &Flavor) -> String {
     )
 }
 
-fn changelog_endpoint(id: &str, flavor: &Flavor) -> String {
-    match flavor {
-        Flavor::Retail | Flavor::RetailPTR | Flavor::RetailBeta => match id {
-            "-1" => "https://www.tukui.org/ui/tukui/changelog".to_owned(),
-            "-2" => "https://www.tukui.org/ui/elvui/changelog".to_owned(),
-            _ => format!("https://www.tukui.org/addons.php?id={}&changelog", id),
-        },
-        Flavor::Classic | Flavor::ClassicPTR => format!(
-            "https://www.tukui.org/classic-addons.php?id={}&changelog",
-            id
-        ),
-    }
-}
 
 /// Function to fetch a remote addon package which contains
 /// information about the addon on the repository.

--- a/crates/core/src/repository/backend/wowi.rs
+++ b/crates/core/src/repository/backend/wowi.rs
@@ -37,18 +37,6 @@ impl Backend for WowI {
 
         Ok(metadata)
     }
-
-    async fn get_changelog(
-        &self,
-        _file_id: Option<i64>,
-        _tag_name: Option<String>,
-    ) -> Result<(String, String), RepositoryError> {
-        Ok((
-            "Please view this changelog in the browser by pressing 'Full Changelog' to the right"
-                .to_owned(),
-            changelog_url(&self.id),
-        ))
-    }
 }
 
 pub(crate) fn metadata_from_wowi_package(package: WowIPackage) -> RepositoryMetadata {

--- a/crates/core/src/repository/backend/wowi.rs
+++ b/crates/core/src/repository/backend/wowi.rs
@@ -75,7 +75,8 @@ pub(crate) fn metadata_from_wowi_package(package: WowIPackage) -> RepositoryMeta
     metadata.remote_packages = remote_packages;
 
     let website_url = addon_url(&package.id.to_string());
-    metadata.website_url = Some(website_url);
+    metadata.website_url = Some(website_url.clone());
+    metadata.changelog_url = Some(format!("{}/#changelog", website_url));
     metadata.title = Some(package.title);
 
     metadata

--- a/crates/core/src/repository/backend/wowi.rs
+++ b/crates/core/src/repository/backend/wowi.rs
@@ -80,10 +80,6 @@ pub(crate) fn addon_url(id: &str) -> String {
     format!("{}{}", ADDON_URL, id)
 }
 
-/// Returns changelog url for addon.
-pub(crate) fn changelog_url(id: &str) -> String {
-    format!("{}{}/#changelog", ADDON_URL, id)
-}
 
 /// Function to fetch a remote addon package which contains
 /// information about the addon on the repository.

--- a/crates/core/src/repository/backend/wowi.rs
+++ b/crates/core/src/repository/backend/wowi.rs
@@ -80,7 +80,6 @@ pub(crate) fn addon_url(id: &str) -> String {
     format!("{}{}", ADDON_URL, id)
 }
 
-
 /// Function to fetch a remote addon package which contains
 /// information about the addon on the repository.
 pub(crate) async fn fetch_remote_packages(

--- a/crates/core/src/repository/mod.rs
+++ b/crates/core/src/repository/mod.rs
@@ -148,44 +148,6 @@ impl RepositoryPackage {
 
         Ok(())
     }
-
-    /// Get changelog from the repository
-    ///
-    /// `channel` and `is_remote` are only used for the Curse repository since
-    /// we can get unique changelogs for each version
-    pub(crate) async fn get_changelog(
-        &self,
-        channel: ReleaseChannel,
-        is_remote: bool,
-    ) -> Result<(String, String), RepositoryError> {
-        let file_id = if self.kind == RepositoryKind::Curse {
-            if is_remote {
-                self.metadata
-                    .remote_packages
-                    .get(&channel)
-                    .map(|p| p.file_id)
-                    .flatten()
-            } else {
-                self.metadata.file_id
-            }
-        } else {
-            None
-        };
-
-        let tag_name = if self.kind.is_git() {
-            let remote_package = self
-                .metadata
-                .remote_packages
-                .get(&channel)
-                .ok_or(RepositoryError::MissingPackageChannel { channel })?;
-
-            Some(remote_package.version.clone())
-        } else {
-            None
-        };
-
-        self.backend.get_changelog(file_id, tag_name).await
-    }
 }
 
 /// Metadata from one of the repository APIs

--- a/crates/core/src/repository/mod.rs
+++ b/crates/core/src/repository/mod.rs
@@ -203,6 +203,10 @@ pub struct RepositoryMetadata {
     pub(crate) game_version: Option<String>,
     pub(crate) file_id: Option<i64>,
 
+    // todo (casperstorm): better description here.
+    // This is constructed, and is different for each repo.
+    pub(crate) changelog_url: Option<String>,
+
     /// Remote packages available from the Repository
     pub(crate) remote_packages: HashMap<ReleaseChannel, RemotePackage>,
 }

--- a/crates/core/src/utility.rs
+++ b/crates/core/src/utility.rs
@@ -25,21 +25,6 @@ pub(crate) fn strip_non_digits(string: &str) -> Option<String> {
     Some(stripped)
 }
 
-pub(crate) fn truncate(s: &str, max_chars: usize) -> &str {
-    match s.char_indices().nth(max_chars) {
-        None => s,
-        Some((idx, _)) => &s[..idx],
-    }
-}
-
-pub(crate) fn regex_html_tags_to_newline() -> Regex {
-    regex::Regex::new(r"<br ?/?>|#.\s").unwrap()
-}
-
-pub(crate) fn regex_html_tags_to_space() -> Regex {
-    regex::Regex::new(r"<[^>]*>|&#?\w+;|[gl]t;").unwrap()
-}
-
 #[derive(Debug, Deserialize, Clone)]
 pub struct Release {
     pub tag_name: String,

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -706,6 +706,7 @@ pub fn addon_data_cell<'a, 'b>(
     let game_version = addon.game_version().map(str::to_string);
     let notes = addon.notes().map(str::to_string);
     let website_url = addon.website_url().map(str::to_string);
+    let changelog_url = addon.changelog_url().map(str::to_string);
     let repository_kind = addon.repository_kind();
 
     // Check if current addon is expanded.
@@ -1327,6 +1328,18 @@ pub fn addon_data_cell<'a, 'b>(
                 .style(style::DefaultDeleteButton(color_palette))
                 .into();
 
+                let mut changelog_button = Button::new(
+                    &mut addon.changelog_btn_state,
+                    Text::new("Changelog").size(DEFAULT_FONT_SIZE),
+                )
+                .style(style::DefaultButton(color_palette));
+
+                if let Some(link) = changelog_url {
+                    changelog_button = changelog_button.on_press(Interaction::OpenLink(link));
+                }
+
+                let changelog_button: Element<Interaction> = changelog_button.into();
+
                 let test_row = Row::new()
                     .push(release_channel_list)
                     .push(release_date_text_container);
@@ -1334,6 +1347,8 @@ pub fn addon_data_cell<'a, 'b>(
                 let button_row = Row::new()
                     .push(Space::new(Length::Fill, Length::Units(0)))
                     .push(website_button.map(Message::Interaction))
+                    .push(Space::new(Length::Units(5), Length::Units(0)))
+                    .push(changelog_button.map(Message::Interaction))
                     .push(Space::new(Length::Units(5), Length::Units(0)))
                     .push(force_download_button.map(Message::Interaction))
                     .push(Space::new(Length::Units(5), Length::Units(0)))

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -2,11 +2,10 @@
 
 use {
     super::{
-        style, BackupFolderKind, BackupState, CatalogColumnKey,
-        CatalogColumnSettings, CatalogColumnState, CatalogRow, ColumnKey, ColumnSettings,
-        ColumnState, DirectoryType, ExpandType, InstallAddon, InstallKind, InstallStatus,
-        Interaction, Message, Mode, ReleaseChannel, ScaleState, SelfUpdateState, SortDirection,
-        State, ThemeState,
+        style, BackupFolderKind, BackupState, CatalogColumnKey, CatalogColumnSettings,
+        CatalogColumnState, CatalogRow, ColumnKey, ColumnSettings, ColumnState, DirectoryType,
+        ExpandType, InstallAddon, InstallKind, InstallStatus, Interaction, Message, Mode,
+        ReleaseChannel, ScaleState, SelfUpdateState, SortDirection, State, ThemeState,
     },
     crate::VERSION,
     ajour_core::{

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -2,18 +2,17 @@
 
 use {
     super::{
-        style, AddonVersionKey, BackupFolderKind, BackupState, CatalogColumnKey,
-        CatalogColumnSettings, CatalogColumnState, CatalogRow, Changelog, ColumnKey,
-        ColumnSettings, ColumnState, DirectoryType, ExpandType, InstallAddon, InstallKind,
-        InstallStatus, Interaction, Message, Mode, ReleaseChannel, ScaleState, SelfUpdateState,
-        SortDirection, State, ThemeState,
+        style, BackupFolderKind, BackupState, CatalogColumnKey,
+        CatalogColumnSettings, CatalogColumnState, CatalogRow, ColumnKey, ColumnSettings,
+        ColumnState, DirectoryType, ExpandType, InstallAddon, InstallKind, InstallStatus,
+        Interaction, Message, Mode, ReleaseChannel, ScaleState, SelfUpdateState, SortDirection,
+        State, ThemeState,
     },
     crate::VERSION,
     ajour_core::{
         addon::{Addon, AddonState},
         catalog::Catalog,
         config::{Config, Flavor},
-        repository::RepositoryKind,
         theme::ColorPalette,
         utility::Release,
     },
@@ -786,59 +785,12 @@ pub fn addon_data_cell<'a, 'b>(
         .next()
     {
         let installed_version = Text::new(version).size(DEFAULT_FONT_SIZE);
-        let mut local_version_button = Button::new(&mut addon.local_btn_state, installed_version)
-            .style(style::BrightTextButton(color_palette));
 
-        if addon_cloned.repository_kind() == Some(RepositoryKind::Curse)
-            && addon_cloned.file_id().is_some()
-        {
-            local_version_button =
-                local_version_button.on_press(Interaction::Expand(ExpandType::Changelog(
-                    Changelog::Request(addon_cloned.clone(), AddonVersionKey::Local),
-                )));
-        }
-
-        if addon_cloned.repository_kind() == Some(RepositoryKind::Tukui)
-            && addon_cloned.repository_id().is_some()
-        {
-            local_version_button =
-                local_version_button.on_press(Interaction::Expand(ExpandType::Changelog(
-                    Changelog::Request(addon_cloned.clone(), AddonVersionKey::Local),
-                )));
-        }
-
-        if addon_cloned.repository_kind() == Some(RepositoryKind::WowI) {
-            local_version_button =
-                local_version_button.on_press(Interaction::Expand(ExpandType::Changelog(
-                    Changelog::Request(addon_cloned.clone(), AddonVersionKey::Local),
-                )));
-        }
-
-        // Lets check if addon is expanded, in changelog mode and local is shown.
-        if is_addon_expanded {
-            if let ExpandType::Changelog(Changelog::Some(_, _, k)) = expand_type {
-                if k == &AddonVersionKey::Local {
-                    local_version_button =
-                        local_version_button.style(style::SelectedBrightTextButton(color_palette));
-                }
-            }
-
-            if let ExpandType::Changelog(Changelog::Loading(_, k)) = expand_type {
-                if k == &AddonVersionKey::Local {
-                    local_version_button =
-                        local_version_button.style(style::SelectedBrightTextButton(color_palette));
-                }
-            }
-        }
-
-        let local_version_button: Element<Interaction> = local_version_button.into();
-
-        let installed_version_container =
-            Container::new(local_version_button.map(Message::Interaction))
-                .height(default_height)
-                .width(*width)
-                .center_y()
-                .style(style::NormalForegroundContainer(color_palette));
+        let installed_version_container = Container::new(installed_version)
+            .height(default_height)
+            .width(*width)
+            .center_y()
+            .style(style::NormalForegroundContainer(color_palette));
 
         row_containers.push((idx, installed_version_container));
     }
@@ -855,66 +807,11 @@ pub fn addon_data_cell<'a, 'b>(
         })
         .next()
     {
-        let mut remote_version_button = Button::new(&mut addon.remote_btn_state, remote_version)
-            .style(style::BrightTextButton(color_palette));
-
-        if addon_cloned.repository_kind() == Some(RepositoryKind::Curse) {
-            if let Some(package) = addon_cloned.relevant_release_package() {
-                if package.file_id.is_some() {
-                    remote_version_button =
-                        remote_version_button.on_press(Interaction::Expand(ExpandType::Changelog(
-                            Changelog::Request(addon_cloned.clone(), AddonVersionKey::Remote),
-                        )));
-                }
-            }
-        }
-
-        if addon_cloned.repository_kind() == Some(RepositoryKind::Tukui)
-            && addon_cloned.repository_id().is_some()
-        {
-            remote_version_button =
-                remote_version_button.on_press(Interaction::Expand(ExpandType::Changelog(
-                    Changelog::Request(addon_cloned.clone(), AddonVersionKey::Remote),
-                )));
-        }
-
-        if addon_cloned.repository_kind() == Some(RepositoryKind::WowI) {
-            remote_version_button =
-                remote_version_button.on_press(Interaction::Expand(ExpandType::Changelog(
-                    Changelog::Request(addon_cloned.clone(), AddonVersionKey::Remote),
-                )));
-        }
-
-        if matches!(addon_cloned.repository_kind(), Some(RepositoryKind::Git(_))) {
-            remote_version_button = remote_version_button.on_press(Interaction::Expand(
-                ExpandType::Changelog(Changelog::Request(addon_cloned, AddonVersionKey::Remote)),
-            ));
-        }
-
-        // Lets check if addon is expanded, in changelog mode and remote is shown.
-        if is_addon_expanded {
-            if let ExpandType::Changelog(Changelog::Some(_, _, k)) = expand_type {
-                if k == &AddonVersionKey::Remote {
-                    remote_version_button =
-                        remote_version_button.style(style::SelectedBrightTextButton(color_palette));
-                }
-            }
-
-            if let ExpandType::Changelog(Changelog::Loading(_, k)) = expand_type {
-                if k == &AddonVersionKey::Remote {
-                    remote_version_button =
-                        remote_version_button.style(style::SelectedBrightTextButton(color_palette));
-                }
-            }
-        }
-
-        let remote_version_button: Element<Interaction> = remote_version_button.into();
-        let remote_version_container =
-            Container::new(remote_version_button.map(Message::Interaction))
-                .height(default_height)
-                .width(*width)
-                .center_y()
-                .style(style::NormalForegroundContainer(color_palette));
+        let remote_version_container = Container::new(remote_version)
+            .height(default_height)
+            .width(*width)
+            .center_y()
+            .style(style::NormalForegroundContainer(color_palette));
 
         row_containers.push((idx, remote_version_container));
     }
@@ -1170,61 +1067,6 @@ pub fn addon_data_cell<'a, 'b>(
 
     if is_addon_expanded {
         match expand_type {
-            ExpandType::Changelog(changelog) => {
-                let changelog_text = match changelog {
-                    Changelog::Some(_, payload, _) => &payload.changelog,
-                    _ => "Loading...",
-                };
-
-                let changelog_title_text = Text::new("Changelog").size(DEFAULT_FONT_SIZE);
-                let changelog_title_container = Container::new(changelog_title_text)
-                    .style(style::BrightForegroundContainer(color_palette));
-
-                let mut full_changelog_button = Button::new(
-                    &mut addon.full_changelog_btn_state,
-                    Text::new("Full Changelog").size(DEFAULT_FONT_SIZE),
-                )
-                .style(style::DefaultButton(color_palette));
-
-                if let ExpandType::Changelog(Changelog::Some(_, p, _)) = expand_type {
-                    full_changelog_button =
-                        full_changelog_button.on_press(Interaction::OpenLink(p.url.clone()));
-                }
-
-                let full_changelog_button: Element<Interaction> = full_changelog_button.into();
-
-                let mut button_row =
-                    Row::new().push(Space::new(Length::FillPortion(1), Length::Units(0)));
-
-                if matches!(changelog, Changelog::Some(_, _, _)) {
-                    button_row = button_row.push(full_changelog_button.map(Message::Interaction));
-                }
-
-                let column = Column::new()
-                    .push(changelog_title_container)
-                    .push(Space::new(Length::Units(0), Length::Units(12)))
-                    .push(Text::new(changelog_text).size(DEFAULT_FONT_SIZE))
-                    .push(Space::new(Length::Units(0), Length::Units(8)))
-                    .push(button_row)
-                    .push(Space::new(Length::Units(0), Length::Units(4)));
-                let details_container = Container::new(column)
-                    .width(Length::Fill)
-                    .padding(20)
-                    .style(style::FadedNormalForegroundContainer(color_palette));
-
-                let row = Row::new()
-                    .push(Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0)))
-                    .push(details_container)
-                    .push(Space::new(
-                        Length::Units(DEFAULT_PADDING + 5),
-                        Length::Units(0),
-                    ))
-                    .spacing(1);
-
-                addon_column = addon_column
-                    .push(Space::new(Length::FillPortion(1), Length::Units(1)))
-                    .push(row);
-            }
             ExpandType::Details(_) => {
                 let notes = notes.unwrap_or_else(|| "No description for addon.".to_string());
                 let author = author.unwrap_or_else(|| "-".to_string());

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -785,6 +785,7 @@ pub fn addon_data_cell<'a, 'b>(
         let installed_version = Text::new(version).size(DEFAULT_FONT_SIZE);
 
         let installed_version_container = Container::new(installed_version)
+            .padding(5)
             .height(default_height)
             .width(*width)
             .center_y()
@@ -806,6 +807,7 @@ pub fn addon_data_cell<'a, 'b>(
         .next()
     {
         let remote_version_container = Container::new(remote_version)
+            .padding(5)
             .height(default_height)
             .width(*width)
             .center_y()

--- a/src/gui/element.rs
+++ b/src/gui/element.rs
@@ -734,9 +734,8 @@ pub fn addon_data_cell<'a, 'b>(
         .next()
     {
         let title = Text::new(addon.title()).size(DEFAULT_FONT_SIZE);
-        let mut title_button = Button::new(&mut addon.details_btn_state, title).on_press(
-            Interaction::Expand(ExpandType::Details(addon_cloned.clone())),
-        );
+        let mut title_button = Button::new(&mut addon.details_btn_state, title)
+            .on_press(Interaction::Expand(ExpandType::Details(addon_cloned)));
 
         if release_package.is_some() {}
 
@@ -1065,172 +1064,167 @@ pub fn addon_data_cell<'a, 'b>(
     let mut addon_column = Column::new().push(row);
 
     if is_addon_expanded {
-        match expand_type {
-            ExpandType::Details(_) => {
-                let notes = notes.unwrap_or_else(|| "No description for addon.".to_string());
-                let author = author.unwrap_or_else(|| "-".to_string());
-                let left_spacer = Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0));
-                let space = Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING * 2));
-                let bottom_space = Space::new(Length::Units(0), Length::Units(4));
-                let notes_title_text = Text::new("Summary").size(DEFAULT_FONT_SIZE);
-                let notes_text = Text::new(notes).size(DEFAULT_FONT_SIZE);
-                let author_text = Text::new(author).size(DEFAULT_FONT_SIZE);
-                let author_title_text = Text::new("Author(s)").size(DEFAULT_FONT_SIZE);
-                let author_title_container = Container::new(author_title_text)
-                    .style(style::FadedBrightForegroundContainer(color_palette));
-                let notes_title_container = Container::new(notes_title_text)
-                    .style(style::FadedBrightForegroundContainer(color_palette));
+        if let ExpandType::Details(_) = expand_type {
+            let notes = notes.unwrap_or_else(|| "No description for addon.".to_string());
+            let author = author.unwrap_or_else(|| "-".to_string());
+            let left_spacer = Space::new(Length::Units(DEFAULT_PADDING), Length::Units(0));
+            let space = Space::new(Length::Units(0), Length::Units(DEFAULT_PADDING * 2));
+            let bottom_space = Space::new(Length::Units(0), Length::Units(4));
+            let notes_title_text = Text::new("Summary").size(DEFAULT_FONT_SIZE);
+            let notes_text = Text::new(notes).size(DEFAULT_FONT_SIZE);
+            let author_text = Text::new(author).size(DEFAULT_FONT_SIZE);
+            let author_title_text = Text::new("Author(s)").size(DEFAULT_FONT_SIZE);
+            let author_title_container = Container::new(author_title_text)
+                .style(style::FadedBrightForegroundContainer(color_palette));
+            let notes_title_container = Container::new(notes_title_text)
+                .style(style::FadedBrightForegroundContainer(color_palette));
 
-                let release_date_text: String = if let Some(package) = &release_package {
-                    let f = timeago::Formatter::new();
-                    let now = Local::now();
+            let release_date_text: String = if let Some(package) = &release_package {
+                let f = timeago::Formatter::new();
+                let now = Local::now();
 
-                    if let Some(time) = package.date_time.as_ref() {
-                        format!("is {}", f.convert_chrono(*time, now))
-                    } else {
-                        "".to_string()
-                    }
+                if let Some(time) = package.date_time.as_ref() {
+                    format!("is {}", f.convert_chrono(*time, now))
                 } else {
-                    "has no avaiable release".to_string()
-                };
-                let release_date_text = Text::new(release_date_text).size(DEFAULT_FONT_SIZE);
-                let release_date_text_container = Container::new(release_date_text)
-                    .center_y()
-                    .padding(5)
-                    .style(style::FadedBrightForegroundContainer(color_palette));
-
-                let release_channel_title =
-                    Text::new("Remote release channel").size(DEFAULT_FONT_SIZE);
-                let release_channel_title_container = Container::new(release_channel_title)
-                    .style(style::FadedBrightForegroundContainer(color_palette));
-                let release_channel_list = PickList::new(
-                    &mut addon.pick_release_channel_state,
-                    &ReleaseChannel::ALL[..],
-                    Some(addon.release_channel),
-                    Message::ReleaseChannelSelected,
-                )
-                .text_size(14)
-                .width(Length::Units(100))
-                .style(style::PickList(color_palette));
-
-                let mut website_button = Button::new(
-                    &mut addon.website_btn_state,
-                    Text::new("Website").size(DEFAULT_FONT_SIZE),
-                )
-                .style(style::DefaultButton(color_palette));
-
-                if let Some(link) = website_url {
-                    website_button = website_button.on_press(Interaction::OpenLink(link));
+                    "".to_string()
                 }
+            } else {
+                "has no avaiable release".to_string()
+            };
+            let release_date_text = Text::new(release_date_text).size(DEFAULT_FONT_SIZE);
+            let release_date_text_container = Container::new(release_date_text)
+                .center_y()
+                .padding(5)
+                .style(style::FadedBrightForegroundContainer(color_palette));
 
-                let website_button: Element<Interaction> = website_button.into();
+            let release_channel_title = Text::new("Remote release channel").size(DEFAULT_FONT_SIZE);
+            let release_channel_title_container = Container::new(release_channel_title)
+                .style(style::FadedBrightForegroundContainer(color_palette));
+            let release_channel_list = PickList::new(
+                &mut addon.pick_release_channel_state,
+                &ReleaseChannel::ALL[..],
+                Some(addon.release_channel),
+                Message::ReleaseChannelSelected,
+            )
+            .text_size(14)
+            .width(Length::Units(100))
+            .style(style::PickList(color_palette));
 
-                let mut force_download_button = Button::new(
-                    &mut addon.force_btn_state,
-                    Text::new("Force update").size(DEFAULT_FONT_SIZE),
-                )
-                .style(style::DefaultButton(color_palette));
+            let mut website_button = Button::new(
+                &mut addon.website_btn_state,
+                Text::new("Website").size(DEFAULT_FONT_SIZE),
+            )
+            .style(style::DefaultButton(color_palette));
 
-                // If we have a release package on addon, enable force update.
-                if release_package.is_some() {
-                    force_download_button = force_download_button
-                        .on_press(Interaction::Update(addon.primary_folder_id.clone()));
-                }
-
-                let force_download_button: Element<Interaction> = force_download_button.into();
-
-                let is_ignored = addon.state == AddonState::Ignored;
-                let ignore_button_text = if is_ignored {
-                    Text::new("Unignore").size(DEFAULT_FONT_SIZE)
-                } else {
-                    Text::new("Ignore").size(DEFAULT_FONT_SIZE)
-                };
-
-                let mut ignore_button =
-                    Button::new(&mut addon.ignore_btn_state, ignore_button_text)
-                        .on_press(Interaction::Ignore(addon.primary_folder_id.clone()))
-                        .style(style::DefaultButton(color_palette));
-
-                if is_ignored {
-                    ignore_button = ignore_button
-                        .on_press(Interaction::Unignore(addon.primary_folder_id.clone()));
-                } else {
-                    ignore_button = ignore_button
-                        .on_press(Interaction::Ignore(addon.primary_folder_id.clone()));
-                }
-
-                let ignore_button: Element<Interaction> = ignore_button.into();
-
-                let delete_button: Element<Interaction> = Button::new(
-                    &mut addon.delete_btn_state,
-                    Text::new("Delete").size(DEFAULT_FONT_SIZE),
-                )
-                .on_press(Interaction::Delete(addon.primary_folder_id.clone()))
-                .style(style::DefaultDeleteButton(color_palette))
-                .into();
-
-                let mut changelog_button = Button::new(
-                    &mut addon.changelog_btn_state,
-                    Text::new("Changelog").size(DEFAULT_FONT_SIZE),
-                )
-                .style(style::DefaultButton(color_palette));
-
-                if let Some(link) = changelog_url {
-                    changelog_button = changelog_button.on_press(Interaction::OpenLink(link));
-                }
-
-                let changelog_button: Element<Interaction> = changelog_button.into();
-
-                let test_row = Row::new()
-                    .push(release_channel_list)
-                    .push(release_date_text_container);
-
-                let button_row = Row::new()
-                    .push(Space::new(Length::Fill, Length::Units(0)))
-                    .push(website_button.map(Message::Interaction))
-                    .push(Space::new(Length::Units(5), Length::Units(0)))
-                    .push(changelog_button.map(Message::Interaction))
-                    .push(Space::new(Length::Units(5), Length::Units(0)))
-                    .push(force_download_button.map(Message::Interaction))
-                    .push(Space::new(Length::Units(5), Length::Units(0)))
-                    .push(ignore_button.map(Message::Interaction))
-                    .push(Space::new(Length::Units(5), Length::Units(0)))
-                    .push(delete_button.map(Message::Interaction))
-                    .width(Length::Fill);
-                let column = Column::new()
-                    .push(author_title_container)
-                    .push(Space::new(Length::Units(0), Length::Units(3)))
-                    .push(author_text)
-                    .push(Space::new(Length::Units(0), Length::Units(15)))
-                    .push(notes_title_container)
-                    .push(Space::new(Length::Units(0), Length::Units(3)))
-                    .push(notes_text)
-                    .push(Space::new(Length::Units(0), Length::Units(15)))
-                    .push(release_channel_title_container)
-                    .push(Space::new(Length::Units(0), Length::Units(3)))
-                    .push(test_row)
-                    .push(space)
-                    .push(button_row)
-                    .push(bottom_space);
-                let details_container = Container::new(column)
-                    .width(Length::Fill)
-                    .padding(20)
-                    .style(style::FadedNormalForegroundContainer(color_palette));
-
-                let row = Row::new()
-                    .push(left_spacer)
-                    .push(details_container)
-                    .push(Space::new(
-                        Length::Units(DEFAULT_PADDING + 5),
-                        Length::Units(0),
-                    ))
-                    .spacing(1);
-
-                addon_column = addon_column
-                    .push(Space::new(Length::FillPortion(1), Length::Units(1)))
-                    .push(row);
+            if let Some(link) = website_url {
+                website_button = website_button.on_press(Interaction::OpenLink(link));
             }
-            _ => {}
+
+            let website_button: Element<Interaction> = website_button.into();
+
+            let mut force_download_button = Button::new(
+                &mut addon.force_btn_state,
+                Text::new("Force update").size(DEFAULT_FONT_SIZE),
+            )
+            .style(style::DefaultButton(color_palette));
+
+            // If we have a release package on addon, enable force update.
+            if release_package.is_some() {
+                force_download_button = force_download_button
+                    .on_press(Interaction::Update(addon.primary_folder_id.clone()));
+            }
+
+            let force_download_button: Element<Interaction> = force_download_button.into();
+
+            let is_ignored = addon.state == AddonState::Ignored;
+            let ignore_button_text = if is_ignored {
+                Text::new("Unignore").size(DEFAULT_FONT_SIZE)
+            } else {
+                Text::new("Ignore").size(DEFAULT_FONT_SIZE)
+            };
+
+            let mut ignore_button = Button::new(&mut addon.ignore_btn_state, ignore_button_text)
+                .on_press(Interaction::Ignore(addon.primary_folder_id.clone()))
+                .style(style::DefaultButton(color_palette));
+
+            if is_ignored {
+                ignore_button =
+                    ignore_button.on_press(Interaction::Unignore(addon.primary_folder_id.clone()));
+            } else {
+                ignore_button =
+                    ignore_button.on_press(Interaction::Ignore(addon.primary_folder_id.clone()));
+            }
+
+            let ignore_button: Element<Interaction> = ignore_button.into();
+
+            let delete_button: Element<Interaction> = Button::new(
+                &mut addon.delete_btn_state,
+                Text::new("Delete").size(DEFAULT_FONT_SIZE),
+            )
+            .on_press(Interaction::Delete(addon.primary_folder_id.clone()))
+            .style(style::DefaultDeleteButton(color_palette))
+            .into();
+
+            let mut changelog_button = Button::new(
+                &mut addon.changelog_btn_state,
+                Text::new("Changelog").size(DEFAULT_FONT_SIZE),
+            )
+            .style(style::DefaultButton(color_palette));
+
+            if let Some(link) = changelog_url {
+                changelog_button = changelog_button.on_press(Interaction::OpenLink(link));
+            }
+
+            let changelog_button: Element<Interaction> = changelog_button.into();
+
+            let test_row = Row::new()
+                .push(release_channel_list)
+                .push(release_date_text_container);
+
+            let button_row = Row::new()
+                .push(Space::new(Length::Fill, Length::Units(0)))
+                .push(website_button.map(Message::Interaction))
+                .push(Space::new(Length::Units(5), Length::Units(0)))
+                .push(changelog_button.map(Message::Interaction))
+                .push(Space::new(Length::Units(5), Length::Units(0)))
+                .push(force_download_button.map(Message::Interaction))
+                .push(Space::new(Length::Units(5), Length::Units(0)))
+                .push(ignore_button.map(Message::Interaction))
+                .push(Space::new(Length::Units(5), Length::Units(0)))
+                .push(delete_button.map(Message::Interaction))
+                .width(Length::Fill);
+            let column = Column::new()
+                .push(author_title_container)
+                .push(Space::new(Length::Units(0), Length::Units(3)))
+                .push(author_text)
+                .push(Space::new(Length::Units(0), Length::Units(15)))
+                .push(notes_title_container)
+                .push(Space::new(Length::Units(0), Length::Units(3)))
+                .push(notes_text)
+                .push(Space::new(Length::Units(0), Length::Units(15)))
+                .push(release_channel_title_container)
+                .push(Space::new(Length::Units(0), Length::Units(3)))
+                .push(test_row)
+                .push(space)
+                .push(button_row)
+                .push(bottom_space);
+            let details_container = Container::new(column)
+                .width(Length::Fill)
+                .padding(20)
+                .style(style::FadedNormalForegroundContainer(color_palette));
+
+            let row = Row::new()
+                .push(left_spacer)
+                .push(details_container)
+                .push(Space::new(
+                    Length::Units(DEFAULT_PADDING + 5),
+                    Length::Units(0),
+                ))
+                .spacing(1);
+
+            addon_column = addon_column
+                .push(Space::new(Length::FillPortion(1), Length::Units(1)))
+                .push(row);
         }
     }
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -5,7 +5,7 @@ mod update;
 use crate::cli::Opts;
 use crate::Result;
 use ajour_core::{
-    addon::{Addon, AddonFolder, AddonState, AddonVersionKey},
+    addon::{Addon, AddonFolder, AddonState},
     cache::{
         load_addon_cache, load_fingerprint_cache, AddonCache, AddonCacheEntry, FingerprintCache,
     },
@@ -146,13 +146,6 @@ pub enum Message {
     BackupFinished(Result<NaiveDateTime, FilesystemError>),
     CatalogDownloaded(Result<Catalog, DownloadError>),
     InstallAddonFetched((Flavor, String, Result<Addon, RepositoryError>)),
-    FetchedChangelog(
-        (
-            Addon,
-            AddonVersionKey,
-            Result<(String, String), RepositoryError>,
-        ),
-    ),
     AjourUpdateDownloaded(Result<(String, PathBuf), DownloadError>),
     AddonCacheUpdated(Result<AddonCacheEntry, CacheError>),
     AddonCacheEntryRemoved(Result<Option<AddonCacheEntry>, CacheError>),
@@ -411,17 +404,6 @@ impl Application for Ajour {
                     // Checks if the current addon is expanded.
                     let is_addon_expanded = match &self.expanded_type {
                         ExpandType::Details(a) => a.primary_folder_id == addon.primary_folder_id,
-                        ExpandType::Changelog(c) => match c {
-                            Changelog::Request(a, _) => {
-                                a.primary_folder_id == addon.primary_folder_id
-                            }
-                            Changelog::Loading(a, _) => {
-                                a.primary_folder_id == addon.primary_folder_id
-                            }
-                            Changelog::Some(a, _, _) => {
-                                a.primary_folder_id == addon.primary_folder_id
-                            }
-                        },
                         ExpandType::None => false,
                     };
 
@@ -893,22 +875,8 @@ impl Default for InstallFromSCMState {
 }
 
 #[derive(Debug, Clone)]
-pub struct ChangelogPayload {
-    changelog: String,
-    url: String,
-}
-
-#[derive(Debug, Clone)]
-pub enum Changelog {
-    Request(Addon, AddonVersionKey),
-    Loading(Addon, AddonVersionKey),
-    Some(Addon, ChangelogPayload, AddonVersionKey),
-}
-
-#[derive(Debug, Clone)]
 pub enum ExpandType {
     Details(Addon),
-    Changelog(Changelog),
     None,
 }
 

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1,9 +1,8 @@
 use {
     super::{
-        Ajour, BackupFolderKind, CatalogCategory, CatalogColumnKey, CatalogRow,
-        CatalogSource, ColumnKey, DirectoryType, DownloadReason, ExpandType,
-        InstallAddon, InstallKind, InstallStatus, Interaction, Message, Mode, SelfUpdateStatus,
-        SortDirection, State,
+        Ajour, BackupFolderKind, CatalogCategory, CatalogColumnKey, CatalogRow, CatalogSource,
+        ColumnKey, DirectoryType, DownloadReason, ExpandType, InstallAddon, InstallKind,
+        InstallStatus, Interaction, Message, Mode, SelfUpdateStatus, SortDirection, State,
     },
     crate::{log_error, Result},
     ajour_core::{

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1,9 +1,9 @@
 use {
     super::{
-        AddonVersionKey, Ajour, BackupFolderKind, CatalogCategory, CatalogColumnKey, CatalogRow,
-        CatalogSource, Changelog, ChangelogPayload, ColumnKey, DirectoryType, DownloadReason,
-        ExpandType, InstallAddon, InstallKind, InstallStatus, Interaction, Message, Mode,
-        SelfUpdateStatus, SortDirection, State,
+        Ajour, BackupFolderKind, CatalogCategory, CatalogColumnKey, CatalogRow,
+        CatalogSource, ColumnKey, DirectoryType, DownloadReason, ExpandType,
+        InstallAddon, InstallKind, InstallStatus, Interaction, Message, Mode, SelfUpdateStatus,
+        SortDirection, State,
     },
     crate::{log_error, Result},
     ajour_core::{
@@ -271,8 +271,6 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                         ajour.expanded_type = expand_type.clone();
                     }
                 }
-                // TODO (casperstorm): cleanup
-                ExpandType::Changelog(changelog) => {},
                 ExpandType::None => {
                     log::debug!("Interaction::Expand(ExpandType::None)");
                 }
@@ -1329,21 +1327,6 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                             }
                         }
                     }
-                }
-            }
-        }
-        Message::FetchedChangelog((addon, key, result)) => {
-            log::debug!("Message::FetchedChangelog(error: {})", &result.is_err());
-            match result.context("Failed to fetch changelog") {
-                Ok((changelog, url)) => {
-                    let payload = ChangelogPayload { changelog, url };
-                    let changelog = Changelog::Some(addon, payload, key);
-                    ajour.expanded_type = ExpandType::Changelog(changelog);
-                }
-                Err(error) => {
-                    log_error(&error);
-                    ajour.error = Some(error);
-                    ajour.expanded_type = ExpandType::None;
                 }
             }
         }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -271,47 +271,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                         ajour.expanded_type = expand_type.clone();
                     }
                 }
-                ExpandType::Changelog(changelog) => match changelog {
-                    // We request changelog.
-                    Changelog::Request(addon, key) => {
-                        log::debug!(
-                            "Interaction::Expand(Changelog::Request({:?}))",
-                            &addon.primary_folder_id
-                        );
-
-                        // Check if the current expanded_type is showing changelog, and is the same
-                        // addon. If this is the case, we close the details.
-
-                        if let ExpandType::Changelog(Changelog::Some(a, _, k)) =
-                            &ajour.expanded_type
-                        {
-                            if addon.primary_folder_id == a.primary_folder_id && key == k {
-                                ajour.expanded_type = ExpandType::None;
-                                return Ok(Command::none());
-                            }
-                        }
-
-                        ajour.expanded_type =
-                            ExpandType::Changelog(Changelog::Loading(addon.clone(), *key));
-                        return Ok(Command::perform(
-                            perform_fetch_changelog(addon.clone(), *key),
-                            Message::FetchedChangelog,
-                        ));
-                    }
-                    Changelog::Loading(a, _) => {
-                        log::debug!(
-                            "Interaction::Expand(Changelog::Loading({:?}))",
-                            &a.primary_folder_id
-                        );
-                        ajour.expanded_type = ExpandType::Changelog(changelog.clone());
-                    }
-                    Changelog::Some(a, _, _) => {
-                        log::debug!(
-                            "Interaction::Expand(Changelog::Some({:?}))",
-                            &a.primary_folder_id
-                        );
-                    }
-                },
+                // TODO (casperstorm): cleanup
+                ExpandType::Changelog(changelog) => {},
                 ExpandType::None => {
                     log::debug!("Interaction::Expand(ExpandType::None)");
                 }
@@ -1565,21 +1526,6 @@ async fn perform_read_addon_directory(
         flavor,
         read_addon_directory(addon_cache, fingerprint_cache, root_dir, flavor).await,
     )
-}
-
-async fn perform_fetch_changelog(
-    addon: Addon,
-    key: AddonVersionKey,
-) -> (
-    Addon,
-    AddonVersionKey,
-    Result<(String, String), RepositoryError>,
-) {
-    let is_remote = key == AddonVersionKey::Remote;
-
-    let result = addon.get_changelog(is_remote).await;
-
-    (addon, key, result)
 }
 
 /// Downloads the newest version of the addon.


### PR DESCRIPTION
## Proposed Changes
  - Not happy with how complex the changelog system is. Also not happy with poorly we are parsing it. It will never be perfect to what I would like because of the different formats. This change will remove the parsed changelogs and add a "Changelog" button in details which opens directly to the relevant page with a changelog.

## Checklist

- [x] Cleanup
- [ ] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
