### PR TITLE
normalize windows path separator for zipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and `Removed`.
 - Ability to retry if a addon fails during either download or unpacking
 - Added a minimum size to Ajour window
 
+### Fixed
+
+- Fixed a bug in backup where the zip archive created on Windows didn't open properly
+  on Linux and Macos. Fixed by converting Windows `\` path separators to `/` before
+  writing to the zip file.
+
 ## [0.5.3] - 2020-11-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "isahc",
  "lazy_static",
  "log",
+ "path-slash",
  "rayon",
  "regex",
  "retry",
@@ -2664,6 +2665,12 @@ dependencies = [
  "smallvec",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "path-slash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff65715a17cba8979903db6294baef56c5d39e05c8b054cffa31e69e61f24c68"
 
 [[package]]
 name = "pathfinder_geometry"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -42,6 +42,7 @@ futures = "0.3"
 async-trait = "0.1.41"
 dyn-clone = "1.0.3"
 thiserror = "1.0"
+path-slash = "0.1.3"
 
 iced_native = { version = "0.3", optional = true }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -17,6 +17,10 @@ pub enum FilesystemError {
     #[cfg(target_os = "macos")]
     #[error("Could not file bin name {bin_name} in archive")]
     BinMissingFromTar { bin_name: String },
+    #[error("Failed to normalize path slashes for {path:?}")]
+    NormalizingPathSlash { path: PathBuf },
+    #[error("Could not strip prefix {prefix:?} from {from:?}")]
+    StripPrefix { prefix: String, from: String },
 }
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
Resolves #385

## Proposed Changes
  - Convert windows path separator from `\` to `/` before writing name to zip file

## Checklist

- [x] Tested on Windows
- [x] Tested on MacOS
- [x] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
