### PR TITLE
Chore/ci improvements

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,6 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-check-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -37,6 +44,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-test-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -72,6 +86,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-clippy-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,4 +1,14 @@
-on: [push, pull_request]
+on:
+  push:
+    paths:
+    - '**.rs'
+    - 'Cargo.lock'
+    - 'Cargo.toml'
+  pull_request:
+    paths:
+    - '**.rs'
+    - 'Cargo.lock'
+    - 'Cargo.toml'
 
 name: Continuous-integration
 


### PR DESCRIPTION
## Proposed Changes
  - Only run CI when program files change. It doesn't need to run when we update README, CHANGELOG, etc.
  - Add caching to improve build times and bust cache if Cargo.lock has changed

## Checklist

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
