### PR TITLE
Fix for bug on #416

### DIFF
--- a/crates/widgets/src/widget/table_row.rs
+++ b/crates/widgets/src/widget/table_row.rs
@@ -224,10 +224,7 @@ where
                 }
                 status_from_content
             }
-            _ => {
-                println!("{:?}", event);
-                status_from_content
-            }
+            _ => status_from_content,
         }
     }
 

--- a/crates/widgets/src/widget/table_row.rs
+++ b/crates/widgets/src/widget/table_row.rs
@@ -207,7 +207,7 @@ where
         );
         match status_from_content {
             event::Status::Ignored => {
-                if let Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) = event {
+                if let Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) = event {
                     if let Some(on_press) = &self.on_press {
                         let bounds = layout.bounds();
                         //We can face issues if the row is expanded, so we manage it by having a reduced bounds area to check for pointer
@@ -224,7 +224,10 @@ where
                 }
                 status_from_content
             }
-            _ => status_from_content,
+            _ => {
+                println!("{:?}", event);
+                status_from_content
+            }
         }
     }
 


### PR DESCRIPTION
Resolves #416 
Changed `Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) `on `table_row`, to `Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))` to avoid having uncaptured event from other widget
