### PR TITLE
add fuzzy match to catalog search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Changed
+
+- Catalog search now uses a fuzzy match for better searching of the catalog.
+
 ## [0.5.4] - 2020-12-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ dependencies = [
  "embed-resource",
  "fern",
  "futures",
+ "fuzzy-matcher",
  "iced",
  "iced_futures",
  "iced_native",
@@ -1350,6 +1351,15 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ futures = "0.3"
 version-compare = "0.0.11"
 open = "1"
 anyhow = "1.0"
+fuzzy-matcher = "0.3.7"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"


### PR DESCRIPTION
Resolves #398

## Proposed Changes
  - When user searches for an addon in the catalog, use a fuzzy match instead of basic string contains logic.
  - Results are sorted by fuzzy match score by default. Columns can still be sorted after the fact, but typing a new character into the query box resets the sort back to fuzzy match score.

## Checklist

- [x] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
