### PR TITLE
Fix/column migration issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix a bug where users upgrading from an older version of Ajour might have incorrect
+  behavior when trying to resize a column in the Catalog
+
 ## [0.5.4] - 2020-12-07
 
 ### Added

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1750,7 +1750,17 @@ fn apply_config(ajour: &mut Ajour, config: Config) {
                     })
                     .next()
                 {
-                    a.width = column.width.map_or(Length::Fill, Length::Units);
+                    // Always force "Title" column as Length::Fill
+                    //
+                    // Shouldn't be an issue here, as it was for catalog column fix
+                    // below, but will cover things in case anyone accidently manually
+                    // modifies their config and sets a fixed width on this column.
+                    a.width = if a.key == ColumnKey::Title {
+                        Length::Fill
+                    } else {
+                        column.width.map_or(Length::Fill, Length::Units)
+                    };
+
                     a.hidden = column.hidden;
                     a.order = idx;
                 }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1807,7 +1807,18 @@ fn apply_config(ajour: &mut Ajour, config: Config) {
                     })
                     .next()
                 {
-                    a.width = column.width.map_or(Length::Fill, Length::Units);
+                    // Always force "Title" column as Length::Fill
+                    //
+                    // An older version of ajour used a different column as the fill
+                    // column and some users have migration issues when updating to
+                    // a newer version, causing NO columns to be set as Fill and
+                    // making resizing columns work incorrectly
+                    a.width = if a.key == CatalogColumnKey::Title {
+                        Length::Fill
+                    } else {
+                        column.width.map_or(Length::Fill, Length::Units)
+                    };
+
                     a.hidden = column.hidden;
                     a.order = idx;
                 }


### PR DESCRIPTION
Resolves #361

## Proposed Changes
  - Always for the "Title" column to be Fill width, regardless of what's set in the config.

## Checklist

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
