### PR TITLE
Fix/fingerprint line split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Certain CF addons weren't fingerprinted correctly due to a bug in the fingerprinting
+  logic for splitting on lines.
+
 ## [0.5.4] - 2020-12-07
 
 ### Added

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -911,7 +911,7 @@ pub fn fingerprint_addon_dir(addon_dir: &PathBuf) -> Result<u32, ParseError> {
 
         let text = String::from_utf8_lossy(&buf);
         let text = comment_strip_regex.replace_all(&text, "");
-        for line in text.split(&['\n', '\r'][..]) {
+        for line in text.lines() {
             let mut last_offset = 0;
             while let Some(inc_match) = inclusion_regex.captures_from_pos(line, last_offset)? {
                 let prev_last_offset = last_offset;


### PR DESCRIPTION
Resolves issue found by Zakrn in discord. He noticed an incorrect fingerprint being calculated in Wowup and tracked the issue to bad line splitting for a certain addon with inconsistent line endings in the file. It appears Ajour was plagued by this too.

I've attached the addon that casues this problem. We previously calculated the fingerprint as `1794641046` but the correct fingerprint is `4110003213`. This change gets us to output `4110003213`. Funny enough, you can't query the CF fingerprint API for either fingerprint, but if you lookup the addon endpoint for addon id `39618` (this addon), you'll see  `4110003213` listed as the fingerprint for the module of the latest file :P So 

[ElvUI_SLE.zip](https://github.com/casperstorm/ajour/files/5662948/ElvUI_SLE.zip)


## Proposed Changes
  - Use the built in line split method for strings

## Checklist

- [x] Tested on Windows
- [x] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
