### PR TITLE
fix: ignored addons are now sorted correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignored addons are now sorted correctly again
+
 ## [0.5.4] - 2020-12-07
 
 ### Added

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -19,12 +19,12 @@ pub enum AddonVersionKey {
 
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub enum AddonState {
+    Ignored,
     Completed,
     Downloading,
     Error(String),
     Fingerprint,
     Idle,
-    Ignored,
     Unknown,
     Unpacking,
     Retry,


### PR DESCRIPTION
Resolves #422

## Proposed Changes
  - Ignored addons are now correctly sorted again.

## Checklist

- [ ] Tested on Windows
- [X] Tested on MacOS
- [ ] Tested on Linux
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
