### PR TITLE
feat: global addon release channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Added
+
+- A global release channel can now be set in Settings. This makes it easy to set
+  all addons to a certain release channel, instead of going through them one by
+  one. Each addon can still overwrite this setting, if wanted.
+
 ### Changed
 
 - Catalog search now uses a fuzzy match for better searching of the catalog.

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -475,8 +475,7 @@ impl Addon {
         }
 
         match release_channel {
-            ReleaseChannel::Default => 
-                None,
+            ReleaseChannel::Default => None,
             ReleaseChannel::Stable => stable_package,
             ReleaseChannel::Beta => {
                 let choose_stable = should_choose_other(&beta_package, &stable_package);

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -1,8 +1,8 @@
 use crate::{
     error::ParseError,
     repository::{
-        ReleaseChannel, RemotePackage, RepositoryIdentifiers, RepositoryKind, RepositoryMetadata,
-        RepositoryPackage, GlobalReleaseChannel,
+        GlobalReleaseChannel, ReleaseChannel, RemotePackage, RepositoryIdentifiers, RepositoryKind,
+        RepositoryMetadata, RepositoryPackage,
     },
     utility::strip_non_digits,
 };
@@ -511,21 +511,25 @@ impl PartialEq for Addon {
 
 impl PartialOrd for Addon {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.title().cmp(&other.title()).then_with(|| {
-            self.relevant_release_package()
-                .cmp(&other.relevant_release_package())
-                .reverse()
-        }))
+        Some(self.title().cmp(&other.title()))
+        // TODO (casperstorm): Is this used?
+        // Some(self.title().cmp(&other.title()).then_with(|| {
+        //     self.relevant_release_package()
+        //         .cmp(&other.relevant_release_package())
+        //         .reverse()
+        // }))
     }
 }
 
 impl Ord for Addon {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.title().cmp(&other.title()).then_with(|| {
-            self.relevant_release_package()
-                .cmp(&other.relevant_release_package())
-                .reverse()
-        })
+        self.title().cmp(&other.title())
+        // TODO (casperstorm): Is this used?
+        // self.title().cmp(&other.title()).then_with(|| {
+        //     self.relevant_release_package()
+        //         .cmp(&other.relevant_release_package())
+        //         .reverse()
+        // })
     }
 }
 impl Eq for Addon {}

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -449,6 +449,12 @@ impl Addon {
         let beta_package = remote_packages.remove(&ReleaseChannel::Beta);
         let alpha_package = remote_packages.remove(&ReleaseChannel::Alpha);
 
+        let release_channel = if self.release_channel == ReleaseChannel::Default {
+            default_release_channel.convert_to_release_channel()
+        } else {
+            self.release_channel
+        };
+
         fn should_choose_other(
             base: &Option<RemotePackage>,
             other: &Option<RemotePackage>,
@@ -468,9 +474,9 @@ impl Addon {
             }
         }
 
-        match &self.release_channel {
-            // TODO: Handle default channel.
-            ReleaseChannel::Default => None,
+        match release_channel {
+            ReleaseChannel::Default => 
+                None,
             ReleaseChannel::Stable => stable_package,
             ReleaseChannel::Beta => {
                 let choose_stable = should_choose_other(&beta_package, &stable_package);

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -467,7 +467,7 @@ impl Addon {
 
         match &self.release_channel {
             // TODO: Handle default channel.
-            ReleaseChannel::Default => None,
+            ReleaseChannel::Default(_) => None,
             ReleaseChannel::Stable => stable_package,
             ReleaseChannel::Beta => {
                 let choose_stable = should_choose_other(&beta_package, &stable_package);

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -2,7 +2,7 @@ use crate::{
     error::ParseError,
     repository::{
         ReleaseChannel, RemotePackage, RepositoryIdentifiers, RepositoryKind, RepositoryMetadata,
-        RepositoryPackage,
+        RepositoryPackage, GlobalReleaseChannel,
     },
     utility::strip_non_digits,
 };
@@ -439,7 +439,10 @@ impl Addon {
 
     /// Returns the relevant release_package for the addon.
     /// Logic is that if a release channel above the selected is newer, we return that instead.
-    pub fn relevant_release_package(&self) -> Option<RemotePackage> {
+    pub fn relevant_release_package(
+        &self,
+        default_release_channel: GlobalReleaseChannel,
+    ) -> Option<RemotePackage> {
         let mut remote_packages = self.remote_packages();
 
         let stable_package = remote_packages.remove(&ReleaseChannel::Stable);
@@ -467,7 +470,7 @@ impl Addon {
 
         match &self.release_channel {
             // TODO: Handle default channel.
-            ReleaseChannel::Default(_) => None,
+            ReleaseChannel::Default => None,
             ReleaseChannel::Stable => stable_package,
             ReleaseChannel::Beta => {
                 let choose_stable = should_choose_other(&beta_package, &stable_package);

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -517,24 +517,13 @@ impl PartialEq for Addon {
 impl PartialOrd for Addon {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.title().cmp(&other.title()))
-        // TODO (casperstorm): Is this used?
-        // Some(self.title().cmp(&other.title()).then_with(|| {
-        //     self.relevant_release_package()
-        //         .cmp(&other.relevant_release_package())
-        //         .reverse()
-        // }))
     }
 }
 
 impl Ord for Addon {
     fn cmp(&self, other: &Self) -> Ordering {
         self.title().cmp(&other.title())
-        // TODO (casperstorm): Is this used?
-        // self.title().cmp(&other.title()).then_with(|| {
-        //     self.relevant_release_package()
-        //         .cmp(&other.relevant_release_package())
-        //         .reverse()
-        // })
     }
 }
+
 impl Eq for Addon {}

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -466,6 +466,8 @@ impl Addon {
         }
 
         match &self.release_channel {
+            // TODO: Handle default channel.
+            ReleaseChannel::Default => None,
             ReleaseChannel::Stable => stable_package,
             ReleaseChannel::Beta => {
                 let choose_stable = should_choose_other(&beta_package, &stable_package);

--- a/crates/core/src/config/addons.rs
+++ b/crates/core/src/config/addons.rs
@@ -1,5 +1,5 @@
 use super::Flavor;
-use crate::repository::ReleaseChannel;
+use crate::repository::{GlobalReleaseChannel, ReleaseChannel};
 use de::de_ignored;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct Addons {
     #[serde(default)]
-    pub default_release_channel: ReleaseChannel,
+    pub global_release_channel: GlobalReleaseChannel,
 
     #[serde(default, deserialize_with = "de_ignored")]
     pub ignored: HashMap<Flavor, Vec<String>>,
@@ -20,7 +20,7 @@ pub struct Addons {
 impl Default for Addons {
     fn default() -> Self {
         Addons {
-            default_release_channel: ReleaseChannel::Stable,
+            global_release_channel: GlobalReleaseChannel::Stable,
             ignored: HashMap::new(),
             release_channels: HashMap::new(),
         }

--- a/crates/core/src/config/addons.rs
+++ b/crates/core/src/config/addons.rs
@@ -7,6 +7,9 @@ use std::collections::HashMap;
 /// Struct for addons specific settings.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct Addons {
+    #[serde(default)]
+    pub default_release_channel: ReleaseChannel,
+
     #[serde(default, deserialize_with = "de_ignored")]
     pub ignored: HashMap<Flavor, Vec<String>>,
 
@@ -17,6 +20,7 @@ pub struct Addons {
 impl Default for Addons {
     fn default() -> Self {
         Addons {
+            default_release_channel: ReleaseChannel::Stable,
             ignored: HashMap::new(),
             release_channels: HashMap::new(),
         }

--- a/crates/core/src/network.rs
+++ b/crates/core/src/network.rs
@@ -1,5 +1,6 @@
 use crate::addon::Addon;
 use crate::error::DownloadError;
+use crate::repository::GlobalReleaseChannel;
 use async_std::{
     fs::{create_dir_all, File},
     io::copy,
@@ -73,14 +74,19 @@ pub(crate) async fn post_json_async<T: ToString, D: Serialize>(
 
 /// Function to download a zip archive for a `Addon`.
 /// Note: Addon needs to have a `remote_url` to the file.
-pub async fn download_addon(addon: &Addon, to_directory: &PathBuf) -> Result<(), DownloadError> {
-    let package = if let Some(relevant_package) = addon.relevant_release_package() {
-        Some(relevant_package)
-    } else if let Some(fallback_package) = addon.fallback_release_package() {
-        Some(fallback_package)
-    } else {
-        None
-    };
+pub async fn download_addon(
+    addon: &Addon,
+    global_release_channel: GlobalReleaseChannel,
+    to_directory: &PathBuf,
+) -> Result<(), DownloadError> {
+    let package =
+        if let Some(relevant_package) = addon.relevant_release_package(global_release_channel) {
+            Some(relevant_package)
+        } else if let Some(fallback_package) = addon.fallback_release_package() {
+            Some(fallback_package)
+        } else {
+            None
+        };
 
     if let Some(package) = package {
         log::debug!(

--- a/crates/core/src/repository/mod.rs
+++ b/crates/core/src/repository/mod.rs
@@ -213,13 +213,15 @@ impl Ord for RemotePackage {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Hash, PartialOrd, Ord)]
 pub enum ReleaseChannel {
+    Default,
     Stable,
     Beta,
     Alpha,
 }
 
 impl ReleaseChannel {
-    pub const ALL: [ReleaseChannel; 3] = [
+    pub const ALL: [ReleaseChannel; 4] = [
+        ReleaseChannel::Default,
         ReleaseChannel::Stable,
         ReleaseChannel::Beta,
         ReleaseChannel::Alpha,
@@ -228,7 +230,7 @@ impl ReleaseChannel {
 
 impl Default for ReleaseChannel {
     fn default() -> ReleaseChannel {
-        ReleaseChannel::Stable
+        ReleaseChannel::Default
     }
 }
 
@@ -238,6 +240,7 @@ impl std::fmt::Display for ReleaseChannel {
             f,
             "{}",
             match self {
+                ReleaseChannel::Default => "Default",
                 ReleaseChannel::Stable => "Stable",
                 ReleaseChannel::Beta => "Beta",
                 ReleaseChannel::Alpha => "Alpha",

--- a/crates/core/src/repository/mod.rs
+++ b/crates/core/src/repository/mod.rs
@@ -227,6 +227,14 @@ impl GlobalReleaseChannel {
         GlobalReleaseChannel::Beta,
         GlobalReleaseChannel::Alpha,
     ];
+
+    pub fn convert_to_release_channel(&self) -> ReleaseChannel {
+        match self {
+            GlobalReleaseChannel::Stable => ReleaseChannel::Stable,
+            GlobalReleaseChannel::Beta => ReleaseChannel::Beta,
+            GlobalReleaseChannel::Alpha => ReleaseChannel::Alpha,
+        }
+    }
 }
 
 impl Default for GlobalReleaseChannel {

--- a/crates/core/src/repository/mod.rs
+++ b/crates/core/src/repository/mod.rs
@@ -254,7 +254,7 @@ impl std::fmt::Display for GlobalReleaseChannel {
 /// is saved in the config.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Hash, PartialOrd, Ord)]
 pub enum ReleaseChannel {
-    Default(GlobalReleaseChannel),
+    Default,
     Stable,
     Beta,
     Alpha,
@@ -262,7 +262,7 @@ pub enum ReleaseChannel {
 
 impl ReleaseChannel {
     pub const ALL: [ReleaseChannel; 4] = [
-        ReleaseChannel::Default(GlobalReleaseChannel::Stable),
+        ReleaseChannel::Default,
         ReleaseChannel::Stable,
         ReleaseChannel::Beta,
         ReleaseChannel::Alpha,
@@ -271,7 +271,7 @@ impl ReleaseChannel {
 
 impl Default for ReleaseChannel {
     fn default() -> ReleaseChannel {
-        ReleaseChannel::Default(GlobalReleaseChannel::Stable)
+        ReleaseChannel::Default
     }
 }
 
@@ -281,7 +281,7 @@ impl std::fmt::Display for ReleaseChannel {
             f,
             "{}",
             match self {
-                ReleaseChannel::Default(_) => "Default",
+                ReleaseChannel::Default => "Default",
                 ReleaseChannel::Stable => "Stable",
                 ReleaseChannel::Beta => "Beta",
                 ReleaseChannel::Alpha => "Alpha",

--- a/crates/core/src/repository/mod.rs
+++ b/crates/core/src/repository/mod.rs
@@ -211,9 +211,50 @@ impl Ord for RemotePackage {
     }
 }
 
+/// This is the global channel used.
+/// If an addon has chosen `Default` as `ReleaseChannel`, we will `GlobalReleaseChannel`
+/// instead, which is saved in the config.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Hash, PartialOrd, Ord)]
+pub enum GlobalReleaseChannel {
+    Stable,
+    Beta,
+    Alpha,
+}
+
+impl GlobalReleaseChannel {
+    pub const ALL: [GlobalReleaseChannel; 3] = [
+        GlobalReleaseChannel::Stable,
+        GlobalReleaseChannel::Beta,
+        GlobalReleaseChannel::Alpha,
+    ];
+}
+
+impl Default for GlobalReleaseChannel {
+    fn default() -> GlobalReleaseChannel {
+        GlobalReleaseChannel::Stable
+    }
+}
+
+impl std::fmt::Display for GlobalReleaseChannel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                GlobalReleaseChannel::Stable => "Stable",
+                GlobalReleaseChannel::Beta => "Beta",
+                GlobalReleaseChannel::Alpha => "Alpha",
+            }
+        )
+    }
+}
+
+/// This is the channel used on an addon level.
+/// If `Default` is chosen, we will use the value from `GlobalReleaseChannel` which
+/// is saved in the config.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Hash, PartialOrd, Ord)]
 pub enum ReleaseChannel {
-    Default,
+    Default(GlobalReleaseChannel),
     Stable,
     Beta,
     Alpha,
@@ -221,7 +262,7 @@ pub enum ReleaseChannel {
 
 impl ReleaseChannel {
     pub const ALL: [ReleaseChannel; 4] = [
-        ReleaseChannel::Default,
+        ReleaseChannel::Default(GlobalReleaseChannel::Stable),
         ReleaseChannel::Stable,
         ReleaseChannel::Beta,
         ReleaseChannel::Alpha,
@@ -230,7 +271,7 @@ impl ReleaseChannel {
 
 impl Default for ReleaseChannel {
     fn default() -> ReleaseChannel {
-        ReleaseChannel::Default
+        ReleaseChannel::Default(GlobalReleaseChannel::Stable)
     }
 }
 
@@ -240,7 +281,7 @@ impl std::fmt::Display for ReleaseChannel {
             f,
             "{}",
             match self {
-                ReleaseChannel::Default => "Default",
+                ReleaseChannel::Default(_) => "Default",
                 ReleaseChannel::Stable => "Stable",
                 ReleaseChannel::Beta => "Beta",
                 ReleaseChannel::Alpha => "Alpha",

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -30,6 +30,8 @@ pub fn install_from_source(url: Uri, flavor: Flavor) -> Result<()> {
         let url_hash = hasher.finish();
 
         let config = load_config().await?;
+        let global_release_channel = config.addons.global_release_channel;
+
         let addon_cache = Arc::new(Mutex::new(load_addon_cache().await?));
         let fingerprint_cache = Arc::new(Mutex::new(load_fingerprint_cache().await?));
 
@@ -47,7 +49,7 @@ pub fn install_from_source(url: Uri, flavor: Flavor) -> Result<()> {
         let addon_directory = config.get_addon_directory_for_flavor(&flavor).ok_or_else(|| format_err!("No WoW directory set. Launch Ajour and make sure a WoW directory is set before using the command line."))?;
 
         // Download the addon
-        download_addon(&addon, &download_directory).await?;
+        download_addon(&addon, global_release_channel, &download_directory).await?;
         log::debug!("Addon downloaded");
 
         // Install the addon and update Addon with the unpacked folders

--- a/src/command/update.rs
+++ b/src/command/update.rs
@@ -12,7 +12,7 @@ use ajour_core::config::{load_config, Flavor};
 use ajour_core::fs::install_addon;
 use ajour_core::network::download_addon;
 use ajour_core::parse::{read_addon_directory, update_addon_fingerprint};
-use ajour_core::repository::RepositoryKind;
+use ajour_core::repository::{GlobalReleaseChannel, RepositoryKind};
 
 use anyhow::{format_err, Context};
 use async_std::sync::{Arc, Mutex};
@@ -28,6 +28,7 @@ pub fn update_all_addons() -> Result<()> {
 
     task::block_on(async {
         let config = load_config().await?;
+        let global_release_channel = config.addons.global_release_channel;
 
         let fingerprint_cache: Arc<Mutex<_>> =
             Arc::new(Mutex::new(load_fingerprint_cache().await?));
@@ -75,7 +76,7 @@ pub fn update_all_addons() -> Result<()> {
                         addon.release_channel = *channel;
                     }
 
-                    if let Some(package) = addon.relevant_release_package() {
+                    if let Some(package) = addon.relevant_release_package(global_release_channel) {
                         // Directory to temporarily save downloaded addon
                         let temp_directory = config
                             .get_download_directory_for_flavor(*flavor)
@@ -87,6 +88,7 @@ pub fn update_all_addons() -> Result<()> {
                                 addon_cache.clone(),
                                 fingerprint_cache.clone(),
                                 *flavor,
+                                global_release_channel,
                                 addon,
                                 temp_directory,
                                 addon_directory.clone(),
@@ -104,10 +106,10 @@ pub fn update_all_addons() -> Result<()> {
 
         addons_to_update
             .iter()
-            .for_each(|(_, _, flavor, addon, ..)| {
+            .for_each(|(_, _, flavor, _, addon, ..)| {
                 let current_version = addon.version().unwrap_or_default();
                 let new_version = addon
-                    .relevant_release_package()
+                    .relevant_release_package(global_release_channel)
                     .map(|p| p.version)
                     .unwrap_or_default();
 
@@ -150,17 +152,26 @@ pub fn update_all_addons() -> Result<()> {
 ///
 /// Downloads the latest file, extracts it and refingerprints the addon, saving it to the cache.
 async fn update_addon(
-    (addon_cache, fingerprint_cache, flavor, mut addon, temp_directory, addon_directory): (
+    (
+        addon_cache,
+        fingerprint_cache,
+        flavor,
+        global_release_channel,
+        mut addon,
+        temp_directory,
+        addon_directory,
+    ): (
         Arc<Mutex<AddonCache>>,
         Arc<Mutex<FingerprintCache>>,
         Flavor,
+        GlobalReleaseChannel,
         Addon,
         PathBuf,
         PathBuf,
     ),
 ) -> Result<()> {
     // Download the update to the temp directory
-    download_addon(&addon, &temp_directory).await?;
+    download_addon(&addon, global_release_channel, &temp_directory).await?;
 
     // Extracts addon from the downloaded archive to the addon directory and removes the archive
     let installed_folders = install_addon(&addon, &temp_directory, &addon_directory).await?;

--- a/src/gui/element/my_addons.rs
+++ b/src/gui/element/my_addons.rs
@@ -1,7 +1,7 @@
 use {
     super::{DEFAULT_FONT_SIZE, DEFAULT_PADDING},
     crate::gui::{
-        style, ColumnKey, ColumnState, Config, ExpandType, Flavor, Interaction, Message, Mode,
+        style, ColumnKey, ColumnState, ExpandType, Flavor, Interaction, Message, Mode,
         ReleaseChannel, SortDirection, State,
     },
     ajour_core::{
@@ -125,8 +125,7 @@ pub fn data_row_container<'a, 'b>(
         .version()
         .map(str::to_string)
         .unwrap_or_else(|| "-".to_string());
-    let release_package =
-        addon_cloned.relevant_release_package(global_release_channel);
+    let release_package = addon_cloned.relevant_release_package(global_release_channel);
     let remote_version = if let Some(package) = &release_package {
         package.version.clone()
     } else {

--- a/src/gui/element/my_addons.rs
+++ b/src/gui/element/my_addons.rs
@@ -149,9 +149,9 @@ pub fn data_row_container<'a, 'b>(
 
         if release_package.is_some() {}
 
-        let mut title_row = Row::new().push(title).spacing(3).align_items(Align::Center);
+        let mut title_row = Row::new().push(title).spacing(5).align_items(Align::Center);
 
-        if addon.release_channel != ReleaseChannel::Stable {
+        if addon.release_channel != ReleaseChannel::Default {
             let release_channel =
                 Container::new(Text::new(addon.release_channel.to_string()).size(10))
                     .style(style::ChannelBadge(color_palette))

--- a/src/gui/element/my_addons.rs
+++ b/src/gui/element/my_addons.rs
@@ -6,6 +6,7 @@ use {
     },
     ajour_core::{
         addon::{Addon, AddonState},
+        config::Config,
         theme::ColorPalette,
     },
     ajour_widgets::{header, Header, TableRow},
@@ -100,6 +101,7 @@ pub fn data_row_container<'a, 'b>(
     addon: &'a mut Addon,
     is_addon_expanded: bool,
     expand_type: &'a ExpandType,
+    config: &Config,
     column_config: &'b [(ColumnKey, Length, bool)],
 ) -> TableRow<'a, Message> {
     let default_height = Length::Units(26);
@@ -114,6 +116,8 @@ pub fn data_row_container<'a, 'b>(
     let changelog_url = addon.changelog_url().map(str::to_string);
     let repository_kind = addon.repository_kind();
 
+    let global_release_channel = config.addons.global_release_channel;
+
     // Check if current addon is expanded.
     let addon_cloned = addon.clone();
     let addon_cloned_for_row = addon.clone();
@@ -121,7 +125,8 @@ pub fn data_row_container<'a, 'b>(
         .version()
         .map(str::to_string)
         .unwrap_or_else(|| "-".to_string());
-    let release_package = addon_cloned.relevant_release_package();
+    let release_package =
+        addon_cloned.relevant_release_package(global_release_channel);
     let remote_version = if let Some(package) = &release_package {
         package.version.clone()
     } else {

--- a/src/gui/element/settings.rs
+++ b/src/gui/element/settings.rs
@@ -318,7 +318,7 @@ pub fn data_container<'a, 'b>(
             Container::new(Text::new("Default Release Channel").size(DEFAULT_FONT_SIZE))
                 .style(style::NormalBackgroundContainer(color_palette));
 
-        // Filter away `ReleaseChannel::Default` because we want to select a actual value. 
+        // Filter away `ReleaseChannel::Default` because we want to select a actual value.
         let release_channels: Vec<_> = ReleaseChannel::ALL
             .to_vec()
             .into_iter()

--- a/src/gui/element/settings.rs
+++ b/src/gui/element/settings.rs
@@ -4,7 +4,7 @@ use {
     super::{DEFAULT_FONT_SIZE, DEFAULT_PADDING},
     crate::gui::{
         style, BackupFolderKind, BackupState, CatalogColumnKey, CatalogColumnSettings, ColumnKey,
-        ColumnSettings, DirectoryType, Interaction, Message, ReleaseChannel, ScaleState,
+        ColumnSettings, DirectoryType, GlobalReleaseChannel, Interaction, Message, ScaleState,
         SelfUpdateChannelState, ThemeState,
     },
     ajour_core::{config::Config, theme::ColorPalette},
@@ -28,7 +28,7 @@ pub fn data_container<'a, 'b>(
     catalog_column_config: &'b [(CatalogColumnKey, Length, bool)],
     open_config_dir_button_state: &'a mut button::State,
     self_update_channel_state: &'a mut SelfUpdateChannelState,
-    default_addon_release_channel_picklist_state: &'a mut pick_list::State<ReleaseChannel>,
+    default_addon_release_channel_picklist_state: &'a mut pick_list::State<GlobalReleaseChannel>,
 ) -> Container<'a, Message> {
     let mut scrollable = Scrollable::new(scrollable_state)
         .spacing(1)
@@ -313,22 +313,16 @@ pub fn data_container<'a, 'b>(
         Column::new().push(checkbox_container)
     };
 
-    let default_release_channel_column = {
+    let global_release_channel_column = {
         let title_container =
-            Container::new(Text::new("Default Release Channel").size(DEFAULT_FONT_SIZE))
+            Container::new(Text::new("Global Release Channel").size(DEFAULT_FONT_SIZE))
                 .style(style::NormalBackgroundContainer(color_palette));
 
-        // Filter away `ReleaseChannel::Default` because we want to select a actual value.
-        let release_channels: Vec<_> = ReleaseChannel::ALL
-            .to_vec()
-            .into_iter()
-            .filter(|rc| rc != &ReleaseChannel::Default)
-            .collect();
         let pick_list: Element<_> = PickList::new(
             default_addon_release_channel_picklist_state,
-            release_channels,
-            Some(config.addons.default_release_channel),
-            Interaction::PickDefaultAddonReleaseChannel,
+            &GlobalReleaseChannel::ALL[..],
+            Some(config.addons.global_release_channel),
+            Interaction::PickGlobalReleaseChannel,
         )
         .text_size(14)
         .width(Length::Units(120))
@@ -431,7 +425,7 @@ pub fn data_container<'a, 'b>(
         .push(Space::new(Length::Units(0), Length::Units(20)))
         .push(addon_title_container)
         .push(Space::new(Length::Units(0), Length::Units(5)))
-        .push(default_release_channel_column)
+        .push(global_release_channel_column)
         .push(Space::new(Length::Units(0), Length::Units(10)))
         .push(hide_addons_column)
         .push(Space::new(Length::Units(0), Length::Units(20)))

--- a/src/gui/element/settings.rs
+++ b/src/gui/element/settings.rs
@@ -4,8 +4,8 @@ use {
     super::{DEFAULT_FONT_SIZE, DEFAULT_PADDING},
     crate::gui::{
         style, BackupFolderKind, BackupState, CatalogColumnKey, CatalogColumnSettings, ColumnKey,
-        ColumnSettings, DirectoryType, Interaction, Message, ScaleState, SelfUpdateChannelState,
-        ThemeState,
+        ColumnSettings, DefaultReleaseChannelState, DirectoryType, Interaction, Message,
+        ReleaseChannel, ScaleState, SelfUpdateChannelState, ThemeState,
     },
     ajour_core::{config::Config, theme::ColorPalette},
     iced::{
@@ -28,6 +28,7 @@ pub fn data_container<'a, 'b>(
     catalog_column_config: &'b [(CatalogColumnKey, Length, bool)],
     open_config_dir_button_state: &'a mut button::State,
     self_update_channel_state: &'a mut SelfUpdateChannelState,
+    default_release_channel_state: &'a mut DefaultReleaseChannelState,
 ) -> Container<'a, Message> {
     let mut scrollable = Scrollable::new(scrollable_state)
         .spacing(1)
@@ -312,6 +313,30 @@ pub fn data_container<'a, 'b>(
         Column::new().push(checkbox_container)
     };
 
+    let default_release_channel_column = {
+        let title_container =
+            Container::new(Text::new("Global Release Channel").size(DEFAULT_FONT_SIZE))
+                .style(style::NormalBackgroundContainer(color_palette));
+
+        let pick_list = PickList::new(
+            &mut default_release_channel_state.picklist,
+            &ReleaseChannel::ALL[..],
+            Some(ReleaseChannel::Stable),
+            Message::DefaultReleaseChannel,
+        )
+        .text_size(14)
+        .width(Length::Units(120))
+        .style(style::PickList(color_palette));
+
+        // Data row for release channel picker list.
+        let data_row = Row::new().push(pick_list);
+
+        Column::new()
+            .push(title_container)
+            .push(Space::new(Length::Units(0), Length::Units(5)))
+            .push(data_row)
+    };
+
     let config_column = {
         let config_dir = ajour_core::fs::config_dir();
         let config_dir_string = config_dir.as_path().display().to_string();
@@ -395,6 +420,8 @@ pub fn data_container<'a, 'b>(
         .push(Space::new(Length::Units(0), Length::Units(20)))
         .push(addon_title_container)
         .push(Space::new(Length::Units(0), Length::Units(5)))
+        .push(default_release_channel_column)
+        .push(Space::new(Length::Units(0), Length::Units(10)))
         .push(hide_addons_column)
         .push(Space::new(Length::Units(0), Length::Units(20)))
         .push(ui_title_container)

--- a/src/gui/element/settings.rs
+++ b/src/gui/element/settings.rs
@@ -309,7 +309,7 @@ pub fn data_container<'a, 'b>(
         .text_size(DEFAULT_FONT_SIZE)
         .spacing(5);
         let checkbox_container =
-            Container::new(checkbox).style(style::BrightBackgroundContainer(color_palette));
+            Container::new(checkbox).style(style::NormalBackgroundContainer(color_palette));
         Column::new().push(checkbox_container)
     };
 
@@ -380,9 +380,9 @@ pub fn data_container<'a, 'b>(
     let addon_title_container =
         Container::new(addon_title).style(style::BrightBackgroundContainer(color_palette));
 
-    let config_title = Text::new("Config").size(DEFAULT_FONT_SIZE);
-    let config_title_container =
-        Container::new(config_title).style(style::BrightBackgroundContainer(color_palette));
+    let ajour_settings_title = Text::new("Ajour").size(DEFAULT_FONT_SIZE);
+    let ajour_settings_title_container =
+        Container::new(ajour_settings_title).style(style::BrightBackgroundContainer(color_palette));
 
     let ui_row = Row::new()
         .push(theme_column)
@@ -390,9 +390,8 @@ pub fn data_container<'a, 'b>(
         .spacing(DEFAULT_PADDING);
 
     let self_update_channel_container = {
-        let channel_title =
-            Container::new(Text::new("Self Update Channel").size(DEFAULT_FONT_SIZE))
-                .style(style::NormalBackgroundContainer(color_palette));
+        let channel_title = Container::new(Text::new("Update Channel").size(DEFAULT_FONT_SIZE))
+            .style(style::NormalBackgroundContainer(color_palette));
         let channel_picklist: Element<_> = PickList::new(
             &mut self_update_channel_state.picklist,
             &self_update_channel_state.options[..],
@@ -433,11 +432,11 @@ pub fn data_container<'a, 'b>(
         .push(Space::new(Length::Units(0), Length::Units(5)))
         .push(ui_row)
         .push(Space::new(Length::Units(0), Length::Units(20)))
-        .push(config_title_container)
+        .push(ajour_settings_title_container)
         .push(Space::new(Length::Units(0), Length::Units(5)))
-        .push(config_column)
+        .push(self_update_channel_container)
         .push(Space::new(Length::Units(0), Length::Units(10)))
-        .push(self_update_channel_container);
+        .push(config_column);
 
     let columns_title_text = Text::new("Columns").size(DEFAULT_FONT_SIZE);
     let columns_title_text_container =

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -126,6 +126,7 @@ pub enum Message {
     ParsedAddons((Flavor, Result<Vec<Addon>, ParseError>)),
     UpdateFingerprint((Flavor, String, Result<(), ParseError>)),
     ThemeSelected(String),
+    // TODO: Rename to addon specific.
     ReleaseChannelSelected(ReleaseChannel),
     ThemesLoaded(Vec<Theme>),
     UnpackedAddon(
@@ -148,6 +149,8 @@ pub enum Message {
     AddonCacheEntryRemoved(Result<Option<AddonCacheEntry>, CacheError>),
     RefreshCatalog(Instant),
     CheckLatestRelease(Instant),
+    // TODO: Rename to DefaultReleaseChannelSelected.
+    DefaultReleaseChannel(ReleaseChannel),
 }
 
 pub struct Ajour {
@@ -195,6 +198,7 @@ pub struct Ajour {
     open_config_dir_btn_state: button::State,
     install_from_scm_state: InstallFromSCMState,
     self_update_channel_state: SelfUpdateChannelState,
+    default_release_channel_state: DefaultReleaseChannelState,
 }
 
 impl Default for Ajour {
@@ -246,6 +250,11 @@ impl Default for Ajour {
             self_update_channel_state: SelfUpdateChannelState {
                 picklist: Default::default(),
                 options: SelfUpdateChannel::all(),
+            },
+            default_release_channel_state: DefaultReleaseChannelState {
+                picklist: Default::default(),
+                // TODO: Change to default when we have created it.
+                release_channel: ReleaseChannel::Stable,
             },
         }
     }
@@ -742,6 +751,7 @@ impl Application for Ajour {
                     &catalog_column_config,
                     &mut self.open_config_dir_btn_state,
                     &mut self.self_update_channel_state,
+                    &mut self.default_release_channel_state,
                 );
 
                 content = content.push(settings_container)
@@ -1653,6 +1663,12 @@ pub struct SelfUpdateState {
 pub struct SelfUpdateChannelState {
     picklist: pick_list::State<SelfUpdateChannel>,
     options: [SelfUpdateChannel; 2],
+}
+
+#[derive(Debug)]
+pub struct DefaultReleaseChannelState {
+    picklist: pick_list::State<ReleaseChannel>,
+    release_channel: ReleaseChannel,
 }
 
 async fn load_caches() -> Result<(FingerprintCache, AddonCache)> {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -111,6 +111,7 @@ pub enum Interaction {
     UpdateAjour,
     ToggleBackupFolder(bool, BackupFolderKind),
     PickSelfUpdateChannel(SelfUpdateChannel),
+    PickDefaultAddonReleaseChannel(ReleaseChannel),
 }
 
 #[derive(Debug)]
@@ -149,8 +150,6 @@ pub enum Message {
     AddonCacheEntryRemoved(Result<Option<AddonCacheEntry>, CacheError>),
     RefreshCatalog(Instant),
     CheckLatestRelease(Instant),
-    // TODO: Rename to DefaultReleaseChannelSelected.
-    DefaultReleaseChannel(ReleaseChannel),
 }
 
 pub struct Ajour {
@@ -198,7 +197,7 @@ pub struct Ajour {
     open_config_dir_btn_state: button::State,
     install_from_scm_state: InstallFromSCMState,
     self_update_channel_state: SelfUpdateChannelState,
-    default_release_channel_state: DefaultReleaseChannelState,
+    default_addon_release_channel_picklist_state: pick_list::State<ReleaseChannel>,
 }
 
 impl Default for Ajour {
@@ -251,11 +250,7 @@ impl Default for Ajour {
                 picklist: Default::default(),
                 options: SelfUpdateChannel::all(),
             },
-            default_release_channel_state: DefaultReleaseChannelState {
-                picklist: Default::default(),
-                // TODO: Change to default when we have created it.
-                release_channel: ReleaseChannel::Stable,
-            },
+            default_addon_release_channel_picklist_state: Default::default(),
         }
     }
 }
@@ -751,7 +746,7 @@ impl Application for Ajour {
                     &catalog_column_config,
                     &mut self.open_config_dir_btn_state,
                     &mut self.self_update_channel_state,
-                    &mut self.default_release_channel_state,
+                    &mut self.default_addon_release_channel_picklist_state,
                 );
 
                 content = content.push(settings_container)
@@ -1663,12 +1658,6 @@ pub struct SelfUpdateState {
 pub struct SelfUpdateChannelState {
     picklist: pick_list::State<SelfUpdateChannel>,
     options: [SelfUpdateChannel; 2],
-}
-
-#[derive(Debug)]
-pub struct DefaultReleaseChannelState {
-    picklist: pick_list::State<ReleaseChannel>,
-    release_channel: ReleaseChannel,
 }
 
 async fn load_caches() -> Result<(FingerprintCache, AddonCache)> {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -14,7 +14,7 @@ use ajour_core::{
     config::{ColumnConfig, ColumnConfigV2, Config, Flavor, SelfUpdateChannel},
     error::*,
     fs::PersistentData,
-    repository::ReleaseChannel,
+    repository::{GlobalReleaseChannel, ReleaseChannel},
     theme::{load_user_themes, Theme},
     utility::{self, get_latest_release},
 };
@@ -111,7 +111,7 @@ pub enum Interaction {
     UpdateAjour,
     ToggleBackupFolder(bool, BackupFolderKind),
     PickSelfUpdateChannel(SelfUpdateChannel),
-    PickDefaultAddonReleaseChannel(ReleaseChannel),
+    PickGlobalReleaseChannel(GlobalReleaseChannel),
 }
 
 #[derive(Debug)]
@@ -197,7 +197,7 @@ pub struct Ajour {
     open_config_dir_btn_state: button::State,
     install_from_scm_state: InstallFromSCMState,
     self_update_channel_state: SelfUpdateChannelState,
-    default_addon_release_channel_picklist_state: pick_list::State<ReleaseChannel>,
+    default_addon_release_channel_picklist_state: pick_list::State<GlobalReleaseChannel>,
 }
 
 impl Default for Ajour {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -424,6 +424,7 @@ impl Application for Ajour {
                         addon,
                         is_addon_expanded,
                         &self.expanded_type,
+                        &self.config,
                         &column_config,
                     );
 

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -805,16 +805,19 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                     }
 
                     // Update config with the newly changed release channel.
-                    ajour
-                        .config
-                        .addons
-                        .release_channels
-                        .entry(flavor)
-                        .or_default()
-                        .insert(addon.primary_folder_id.clone(), release_channel);
+                    // Unless its default, then we dont need it in config.
+                    if release_channel != ReleaseChannel::Default {
+                        ajour
+                            .config
+                            .addons
+                            .release_channels
+                            .entry(flavor)
+                            .or_default()
+                            .insert(addon.primary_folder_id.clone(), release_channel);
 
-                    // Persist the newly updated config.
-                    let _ = &ajour.config.save();
+                        // Persist the newly updated config.
+                        let _ = &ajour.config.save();
+                    }
                 }
             }
         }

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1496,6 +1496,9 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 Message::LatestRelease,
             ));
         }
+        Message::DefaultReleaseChannel(channel) => {
+            println!("{:?}", channel);
+        }
         Message::Error(error) => {
             log_error(&error);
             ajour.error = Some(error);

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1,6 +1,6 @@
 use {
     super::{
-        Ajour, BackupFolderKind, CatalogCategory, CatalogColumnKey, CatalogRow, CatalogSource,
+        Ajour, ReleaseChannel, BackupFolderKind, CatalogCategory, CatalogColumnKey, CatalogRow, CatalogSource,
         ColumnKey, DirectoryType, DownloadReason, ExpandType, GlobalReleaseChannel, InstallAddon,
         InstallKind, InstallStatus, Interaction, Message, Mode, SelfUpdateStatus, SortDirection,
         State,
@@ -414,13 +414,8 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                             {
                                 a.release_channel = *release_channel;
                             } else {
-                                // Else we try to determine the release_channel based of installed version.
-                                for (release_channel, package) in a.remote_packages() {
-                                    if package.file_id == a.file_id() {
-                                        a.release_channel = release_channel.to_owned();
-                                        break;
-                                    }
-                                }
+                                // Else we set it to the default release channel.
+                                a.release_channel = ReleaseChannel::Default;
                             }
 
                             // Check if addon is updatable based on release channel.

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -164,10 +164,11 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
 
             // Update ajour state.
             let flavor = ajour.config.wow.flavor;
+            let global_release_channel = ajour.config.addons.global_release_channel;
             let addons = ajour.addons.entry(flavor).or_default();
             if let Some(addon) = addons.iter_mut().find(|a| a.primary_folder_id == id) {
                 // Check if addon is updatable.
-                if let Some(package) = addon.relevant_release_package() {
+                if let Some(package) = addon.relevant_release_package(global_release_channel) {
                     if addon.is_updatable(&package) {
                         addon.state = AddonState::Updatable;
                     } else {

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1488,6 +1488,13 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 Message::LatestRelease,
             ));
         }
+        Message::Interaction(Interaction::PickDefaultAddonReleaseChannel(channel)) => {
+            log::debug!("Interaction::PickDefaultAddonReleaseChannel({:?})", channel);
+
+            ajour.config.addons.default_release_channel = channel;
+
+            let _ = ajour.config.save();
+        }
         Message::CheckLatestRelease(_) => {
             log::debug!("Message::CheckLatestRelease");
 
@@ -1495,9 +1502,6 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 get_latest_release(ajour.config.self_update_channel),
                 Message::LatestRelease,
             ));
-        }
-        Message::DefaultReleaseChannel(channel) => {
-            println!("{:?}", channel);
         }
         Message::Error(error) => {
             log_error(&error);

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1488,10 +1488,10 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 Message::LatestRelease,
             ));
         }
-        Message::Interaction(Interaction::PickDefaultAddonReleaseChannel(channel)) => {
-            log::debug!("Interaction::PickDefaultAddonReleaseChannel({:?})", channel);
+        Message::Interaction(Interaction::PickGlobalReleaseChannel(channel)) => {
+            log::debug!("Interaction::PickGlobalReleaseChannel({:?})", channel);
 
-            ajour.config.addons.default_release_channel = channel;
+            ajour.config.addons.global_release_channel = channel;
 
             let _ = ajour.config.save();
         }


### PR DESCRIPTION
Resolves #236 #185 #231

## Proposed Changes
  - We will create a way to control release channels at a global level.

## Checklist

- [x] Update all addons which is `default` on selection.
- [x] Ensure we download the correct release from catalog. With fallbacks.
- [x] Migration (All `stable` goes to `default`).
- [x] Tested on Windows
- [x] Tested on MacOS
- [x] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
