### PR TITLE
remove addon cache entries on missing addon folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and `Removed`.
 - Fix a bug where users upgrading from an older version of Ajour might have incorrect
   behavior when trying to resize a column in the Catalog
 - Ignored addons are now sorted correctly again
+- Fingerprint and addon cache entries are now properly deleted when the addon folder
+  is missing from the filesystem
 
 ## [0.5.4] - 2020-12-07
 

--- a/crates/core/src/cache.rs
+++ b/crates/core/src/cache.rs
@@ -21,6 +21,14 @@ impl FingerprintCache {
     pub(crate) fn get_mut_for_flavor(&mut self, flavor: Flavor) -> &mut Vec<Fingerprint> {
         self.0.entry(flavor).or_default()
     }
+
+    pub(crate) fn flavor_exists(&self, flavor: Flavor) -> bool {
+        self.0.contains_key(&flavor)
+    }
+
+    pub(crate) fn delete_flavor(&mut self, flavor: Flavor) {
+        self.0.remove_entry(&flavor);
+    }
 }
 
 impl PersistentData for FingerprintCache {

--- a/crates/core/src/cache.rs
+++ b/crates/core/src/cache.rs
@@ -138,11 +138,11 @@ pub async fn remove_addon_cache_entry(
     }
 }
 
-/// Removes cache entires that have folder
+/// Removes addon cache entires that have folder
 /// names that are missing in the input `folders`
 ///
 /// Pass `false` to save_cache for testing purposes
-pub async fn remove_entries_with_missing_folders(
+pub async fn remove_addon_entries_with_missing_folders(
     addon_cache: Arc<Mutex<AddonCache>>,
     flavor: Flavor,
     folders: &[AddonFolder],
@@ -273,7 +273,7 @@ mod test {
             // Remove partial 1 folder from the first 10, then all folders of
             // the last 10. Only the middle 10 folders are fully in tact,
             // meaning on the 2nd entry should remain after this operation
-            let num_deleted = remove_entries_with_missing_folders(
+            let num_deleted = remove_addon_entries_with_missing_folders(
                 cache.clone(),
                 flavor,
                 &addon_folders[5..20],

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -155,6 +155,8 @@ pub enum ParseError {
     Download(#[from] DownloadError),
     #[error(transparent)]
     Filesystem(#[from] FilesystemError),
+    #[error(transparent)]
+    Cache(#[from] CacheError),
 }
 
 impl From<std::io::Error> for ParseError {

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -310,7 +310,7 @@ async fn get_cache_entries(
         // Remove any cached entries for folders that no longer exist
         // on the filesystem
         {
-            let num_removed = cache::remove_entries_with_missing_folders(
+            let num_removed = cache::remove_addon_entries_with_missing_folders(
                 addon_cache.clone(),
                 flavor,
                 addon_folders,


### PR DESCRIPTION

## Proposed Changes
  - Remove addon cache entries when it's folders no longer exist on the filesystem

## Checklist

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
