### PR TITLE
add padding back to titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and `Removed`.
 - Ignored addons are now sorted correctly again
 - Fingerprint and addon cache entries are now properly deleted when the addon folder
   is missing from the filesystem
+- Padding was added back on My Addon and Catalog title columns, which was unintentionally
+  removed when implementing highlightable rows
 
 ## [0.5.4] - 2020-12-07
 

--- a/src/gui/element/catalog.rs
+++ b/src/gui/element/catalog.rs
@@ -195,6 +195,7 @@ pub fn data_row_container<'a, 'b>(
         let title = Text::new(&addon_data.name).size(DEFAULT_FONT_SIZE);
 
         let title_container = Container::new(title)
+            .padding(5)
             .height(default_height)
             .width(*width)
             .center_y()

--- a/src/gui/element/my_addons.rs
+++ b/src/gui/element/my_addons.rs
@@ -147,8 +147,6 @@ pub fn data_row_container<'a, 'b>(
     {
         let title = Text::new(addon.title()).size(DEFAULT_FONT_SIZE);
 
-        if release_package.is_some() {}
-
         let mut title_row = Row::new().push(title).spacing(5).align_items(Align::Center);
 
         if addon.release_channel != ReleaseChannel::Default {
@@ -161,6 +159,7 @@ pub fn data_row_container<'a, 'b>(
         }
 
         let mut title_container = Container::new(title_row)
+            .padding(5)
             .height(default_height)
             .width(*width)
             .center_y();


### PR DESCRIPTION
There was a regression in 0.5.4 once highlight rows was enabled that removed padding from the Title of My Addons and Catalog. The text for these used to be wrapped in a Button, which by default has a padding of 5 on it's contents. I fixed this by adding the padding of 5 back on the text's container. This also fixes the regression where the title would visibly "wrap" without this padding.

You can see the default padding of a button here:

https://github.com/hecrj/iced/blob/master/graphics/src/widget/button.rs#L24

### Before

![Screenshot from 2020-12-17 15-52-26](https://user-images.githubusercontent.com/10239377/102558055-743c4d80-4081-11eb-85d9-4f7770c933ba.png)


### After

![Screenshot from 2020-12-17 16-04-22](https://user-images.githubusercontent.com/10239377/102558091-8cac6800-4081-11eb-8924-b037d597ee7a.png)


## Checklist

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
