### PR TITLE
fix: linux resizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and `Removed`.
 
 ### Fixed
 
+- Removed minimum window size on Linux. This fixed a issue where the application would
+  not be resizable.
 - Certain CF addons weren't fingerprinted correctly due to a bug in the fingerprinting
   logic for splitting on lines.
 - Fix a bug where users upgrading from an older version of Ajour might have incorrect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ and `Removed`.
 
 ### Fixed
 
-- Removed minimum window size on Linux. This fixed a issue where the application would
-  not be resizable.
+- Removed minimum window size on Linux. This fixed a issue where the application
+  would not be resizable.
 - Certain CF addons weren't fingerprinted correctly due to a bug in the fingerprinting
   logic for splitting on lines.
 - Fix a bug where users upgrading from an older version of Ajour might have incorrect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed minimum window size on Linux. This fixed a issue where the application
+  would not be resizable.
+
 ## [0.6.0] - 2020-12-20
 
 ### Added
@@ -33,8 +38,6 @@ and `Removed`.
 
 ### Fixed
 
-- Removed minimum window size on Linux. This fixed a issue where the application
-  would not be resizable.
 - Certain CF addons weren't fingerprinted correctly due to a bug in the fingerprinting
   logic for splitting on lines.
 - Fix a bug where users upgrading from an older version of Ajour might have incorrect

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -984,7 +984,14 @@ pub fn run(opts: Opts) {
 
     let mut settings = Settings::default();
     settings.window.size = config.window_size.unwrap_or((900, 620));
-    settings.window.min_size = Some((600, 300));
+
+    #[cfg(not(target_os = "linux"))]
+    // TODO (casperstorm): Due to an upstream bug, min_size causes the window to become unresizable
+    // on Linux.
+    // @see: https://github.com/casperstorm/ajour/issues/427
+    {
+        settings.window.min_size = Some((600, 300));
+    }
 
     #[cfg(feature = "wgpu")]
     {


### PR DESCRIPTION
Resolves #427 

## Proposed Changes
  - Disabled minimum window size on Linux because it causes the window to become non-resizable.

## Checklist

- [ ] Tested on Windows
- [X] Tested on MacOS
- [x] Tested on Linux
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
