### PR TITLE
fix: username is now optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Fix
+
+- Now correctly parses WeakAuars uploaded to Wago as a guest.
+
 ## [0.6.0] - 2020-12-20
 
 ### Added

--- a/crates/weak_auras/src/lib.rs
+++ b/crates/weak_auras/src/lib.rs
@@ -183,7 +183,7 @@ impl AuraUpdate {
 
         writeln!(&mut slug, "    [\"{}\"] = {{", self.slug)?;
         writeln!(&mut slug, "      name = [=[{}]=],", self.aura.name)?;
-        writeln!(&mut slug, "      author = [=[{}]=],", self.aura.author().to_owned())?;
+        writeln!(&mut slug, "      author = [=[{}]=],", self.aura.author())?;
         writeln!(&mut slug, "      encoded = [=[{}]=],", self.encoded_update)?;
         writeln!(&mut slug, "      wagoVersion = [=[{}]=],", self.aura.version)?;
         writeln!(&mut slug, "      wagoSemver = [=[{}]=],", self.aura.version_string)?;

--- a/crates/weak_auras/src/lib.rs
+++ b/crates/weak_auras/src/lib.rs
@@ -183,7 +183,7 @@ impl AuraUpdate {
 
         writeln!(&mut slug, "    [\"{}\"] = {{", self.slug)?;
         writeln!(&mut slug, "      name = [=[{}]=],", self.aura.name)?;
-        writeln!(&mut slug, "      author = [=[{}]=],", self.aura.username)?;
+        writeln!(&mut slug, "      author = [=[{}]=],", self.aura.author().to_owned())?;
         writeln!(&mut slug, "      encoded = [=[{}]=],", self.encoded_update)?;
         writeln!(&mut slug, "      wagoVersion = [=[{}]=],", self.aura.version)?;
         writeln!(&mut slug, "      wagoSemver = [=[{}]=],", self.aura.version_string)?;
@@ -264,7 +264,7 @@ impl Display for AuraStatus {
 pub struct Aura {
     slug: String,
     name: String,
-    username: String,
+    username: Option<String>,
     version: u16,
     version_string: String,
     changelog: AuraChangelog,
@@ -329,7 +329,10 @@ impl Aura {
     }
 
     pub fn author(&self) -> &str {
-        &self.username
+        match &self.username {
+            Some(username) => username,
+            None => "Unknown",
+        }
     }
 
     fn parent_display(&self) -> Option<&AuraDisplay> {


### PR DESCRIPTION
Resolves #442 

## Proposed Changes
  - Apparently you can submit auras without having an account so `username `is null. I did a quick fix to make it optional.
  - @tarkah can you look at if there's a more smooth way of handling this?

## Checklist

- [X] Tested on Windows
- [X] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
