### PR TITLE
add pre-release channel for github addons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ and `Removed`.
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
 - Added "Beta / Alpha" release channel support for GitHub addons. Releases marked
   as "pre-release" on GitHub will show as an update when the addon is marked as
   "Beta" or "Alpha". Releases not marked as "pre-release" will show up for "Stable".
+
+### Fixed
 - Fixed addon title letter casing for GitHub addons by using the actual repository
   name instead of parsed repo from the user inputted URL
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and `Removed`.
   "Beta" or "Alpha". Releases not marked as "pre-release" will show up for "Stable".
 
 ### Fixed
+
 - Fixed addon title letter casing for GitHub addons by using the actual repository
   name instead of parsed repo from the user inputted URL
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Added "Beta / Alpha" release channel support for GitHub addons. Releases marked
+  as "pre-release" on GitHub will show as an update when the addon is marked as
+  "Beta" or "Alpha". Releases not marked as "pre-release" will show up for "Stable".
+- Fixed addon title letter casing for GitHub addons by using the actual repository
+  name instead of parsed repo from the user inputted URL
+
 ## [0.6.0] - 2020-12-20
 
 ### Added

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -1,8 +1,8 @@
 use crate::{
     error::ParseError,
     repository::{
-        GlobalReleaseChannel, ReleaseChannel, RemotePackage, RepositoryIdentifiers, RepositoryKind,
-        RepositoryMetadata, RepositoryPackage,
+        GitKind, GlobalReleaseChannel, ReleaseChannel, RemotePackage, RepositoryIdentifiers,
+        RepositoryKind, RepositoryMetadata, RepositoryPackage,
     },
     utility::strip_non_digits,
 };
@@ -328,10 +328,24 @@ impl Addon {
     }
 
     /// Returns the changelog url of the addon.
-    pub fn changelog_url(&self) -> Option<&str> {
-        self.metadata()
-            .map(|m| m.changelog_url.as_deref())
-            .flatten()
+    pub fn changelog_url(&self, default_release_channel: GlobalReleaseChannel) -> Option<String> {
+        let url = self.metadata().map(|m| m.changelog_url.clone()).flatten();
+
+        match self.repository_kind() {
+            Some(RepositoryKind::Git(GitKind::Github)) => {
+                let tag = self
+                    .relevant_release_package(default_release_channel)
+                    .map(|r| r.version);
+
+                if let Some(tag) = tag {
+                    url.map(|url| format!("{}/tag/{}", url, tag))
+                } else {
+                    url
+                }
+            }
+            Some(_) => url,
+            None => None,
+        }
     }
 
     /// Returns the curse id of the addon, if applicable.

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -107,6 +107,8 @@ pub enum RepositoryError {
     Download(#[from] DownloadError),
     #[error(transparent)]
     Filesystem(#[from] FilesystemError),
+    #[error(transparent)]
+    Uri(#[from] isahc::http::uri::InvalidUri),
 }
 
 impl From<std::io::Error> for RepositoryError {

--- a/crates/core/src/repository/backend/git.rs
+++ b/crates/core/src/repository/backend/git.rs
@@ -35,85 +35,144 @@ mod github {
                 url: self.url.to_string(),
             })?;
 
-            let url = format!(
-                "https://api.github.com/repos/{}/{}/releases/latest",
-                author, repo
-            );
+            let url = format!("https://api.github.com/repos/{}/{}/releases", author, repo);
 
             let mut resp = request_async(&url, vec![], None).await?;
 
-            let release: Release = resp
+            let releases: Vec<Release> = resp
                 .json()
                 .map_err(|_| RepositoryError::GitMissingRelease { url: url.clone() })?;
 
-            let num_non_classic = release
-                .assets
-                .iter()
-                .filter(|a| a.name.ends_with("zip"))
-                .filter(|a| !a.name.to_lowercase().contains("classic"))
-                .count();
-            let num_classic = release
-                .assets
-                .iter()
-                .filter(|a| a.name.ends_with("zip"))
-                .filter(|a| a.name.to_lowercase().contains("classic"))
-                .count();
+            let stable_release = releases.iter().find(|r| !r.prerelease);
+            let beta_release = releases.iter().find(|r| r.prerelease);
 
-            if self.flavor.base_flavor() == Flavor::Retail && num_non_classic > 1
-                || self.flavor.base_flavor() == Flavor::Classic
-                    && num_classic == 0
-                    && num_non_classic > 1
-            {
-                return Err(RepositoryError::GitIndeterminableZip {
-                    count: num_non_classic,
-                    url: url.clone(),
-                });
-            } else if self.flavor.base_flavor() == Flavor::Classic && num_classic > 1 {
-                return Err(RepositoryError::GitIndeterminableZipClassic {
-                    count: num_classic,
-                    url,
-                });
+            if stable_release.is_none() && beta_release.is_none() {
+                return Err(RepositoryError::GitMissingRelease { url: url.clone() });
             }
 
-            let asset = release
-                .assets
-                .iter()
-                .find(|a| {
-                    if self.flavor.base_flavor() == Flavor::Retail {
-                        a.name.ends_with("zip") && !a.name.to_lowercase().contains("classic")
-                    } else if num_classic > 0 {
-                        a.name.ends_with("zip") && a.name.to_lowercase().contains("classic")
-                    } else {
-                        a.name.ends_with("zip")
-                    }
-                })
-                .ok_or(RepositoryError::GitNoZip { url })?;
-
-            let version = release.tag_name.clone();
-            let download_url = asset.browser_download_url.clone();
-            let date_time = Some(release.published_at);
-
             let mut remote_packages = HashMap::new();
-            let remote_package = RemotePackage {
-                version: version.clone(),
-                download_url,
-                date_time,
-                file_id: None,
-                modules: vec![],
-            };
 
-            remote_packages.insert(ReleaseChannel::Stable, remote_package);
+            if let Some(release) = stable_release {
+                set_remote_package(
+                    self.flavor,
+                    &url,
+                    &mut remote_packages,
+                    ReleaseChannel::Stable,
+                    release,
+                )?;
+            }
+
+            if let Some(release) = beta_release {
+                set_remote_package(
+                    self.flavor,
+                    &url,
+                    &mut remote_packages,
+                    ReleaseChannel::Beta,
+                    release,
+                )?;
+            }
+
+            // URL passed in by user might not be the correct letter casing. Let's
+            // use the url from the API response instead to ensure the title we
+            // use for the addon has the correct letter casing.
+            let title = {
+                let release = if stable_release.is_some() {
+                    stable_release.unwrap()
+                } else {
+                    beta_release.unwrap()
+                };
+
+                let html_url = release.html_url.parse::<Uri>()?;
+
+                let mut path = html_url.path().split('/');
+                path.next();
+                path.next();
+
+                path.next()
+                    .ok_or(RepositoryError::GitMissingRepo {
+                        url: self.url.to_string(),
+                    })?
+                    .to_string()
+            };
 
             let metadata = RepositoryMetadata {
                 website_url: Some(self.url.to_string()),
-                changelog_url: Some(format!("{}/releases/tag/{}", self.url, version)),
+                changelog_url: Some(format!("{}/releases", self.url)),
                 remote_packages,
-                title: Some(repo.to_string()),
+                title: Some(title),
                 ..Default::default()
             };
 
             Ok(metadata)
         }
+    }
+
+    fn set_remote_package(
+        flavor: Flavor,
+        url: &str,
+        remote_packages: &mut HashMap<ReleaseChannel, RemotePackage>,
+        release_channel: ReleaseChannel,
+        release: &Release,
+    ) -> Result<(), RepositoryError> {
+        let num_non_classic = release
+            .assets
+            .iter()
+            .filter(|a| a.name.ends_with("zip"))
+            .filter(|a| !a.name.to_lowercase().contains("classic"))
+            .count();
+
+        let num_classic = release
+            .assets
+            .iter()
+            .filter(|a| a.name.ends_with("zip"))
+            .filter(|a| a.name.to_lowercase().contains("classic"))
+            .count();
+
+        if flavor.base_flavor() == Flavor::Retail && num_non_classic > 1
+            || flavor.base_flavor() == Flavor::Classic && num_classic == 0 && num_non_classic > 1
+        {
+            return Err(RepositoryError::GitIndeterminableZip {
+                count: num_non_classic,
+                url: url.to_string(),
+            });
+        } else if flavor.base_flavor() == Flavor::Classic && num_classic > 1 {
+            return Err(RepositoryError::GitIndeterminableZipClassic {
+                count: num_classic,
+                url: url.to_string(),
+            });
+        }
+
+        let asset = release
+            .assets
+            .iter()
+            .find(|a| {
+                if flavor.base_flavor() == Flavor::Retail {
+                    a.name.ends_with("zip") && !a.name.to_lowercase().contains("classic")
+                } else if num_classic > 0 {
+                    a.name.ends_with("zip") && a.name.to_lowercase().contains("classic")
+                } else {
+                    a.name.ends_with("zip")
+                }
+            })
+            .ok_or(RepositoryError::GitNoZip {
+                url: url.to_string(),
+            })?;
+
+        let version = release.tag_name.clone();
+        let download_url = asset.browser_download_url.clone();
+        let date_time = Some(release.published_at);
+
+        let remote_package = RemotePackage {
+            version,
+            download_url,
+            date_time,
+            file_id: None,
+            modules: vec![],
+        };
+
+        remote_packages.insert(release_channel, remote_package);
+
+        Ok(())
     }
 
     #[derive(Debug, Deserialize, Clone)]

--- a/src/gui/element/my_addons.rs
+++ b/src/gui/element/my_addons.rs
@@ -113,7 +113,7 @@ pub fn data_row_container<'a, 'b>(
     let game_version = addon.game_version().map(str::to_string);
     let notes = addon.notes().map(str::to_string);
     let website_url = addon.website_url().map(str::to_string);
-    let changelog_url = addon.changelog_url().map(str::to_string);
+    let changelog_url = addon.changelog_url(config.addons.global_release_channel);
     let repository_kind = addon.repository_kind();
 
     let global_release_channel = config.addons.global_release_channel;


### PR DESCRIPTION
Resolves #438

## Proposed Changes
- Added "Beta / Alpha" release channel support for GitHub addons. Releases marked
  as "pre-release" on GitHub will show as an update when the addon is marked as
  "Beta" or "Alpha". Releases not marked as "pre-release" will show up for "Stable".
- Fixed addon title letter casing for GitHub addons by using the actual repository
  name instead of parsed repo from the user inputted URL

## Checklist

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [x] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
