### PR TITLE
include Interface root in AddOns backup path 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Changes
+
+- `Interface` folder root is included in the zip backup when `AddOns` is selected.
+  Some users store proprietary data alongside the `AddOns` folder that they'd like
+  included during backup.
+
 ## [0.6.0] - 2020-12-20
 
 ### Added

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1085,7 +1085,7 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 if ajour.config.backup_addons {
                     let addon_dir = ajour.config.get_addon_directory_for_flavor(flavor).unwrap();
 
-                    // Backup starting with `Interface` fodler as some users save
+                    // Backup starting with `Interface` folder as some users save
                     // custom data here that they would like retained
                     if let Some(interface_dir) = addon_dir.parent() {
                         if interface_dir.exists() {

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1085,8 +1085,12 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 if ajour.config.backup_addons {
                     let addon_dir = ajour.config.get_addon_directory_for_flavor(flavor).unwrap();
 
-                    if addon_dir.exists() {
-                        src_folders.push(BackupFolder::new(&addon_dir, wow_dir));
+                    // Backup starting with `Interface` fodler as some users save
+                    // custom data here that they would like retained
+                    if let Some(interface_dir) = addon_dir.parent() {
+                        if interface_dir.exists() {
+                            src_folders.push(BackupFolder::new(interface_dir, wow_dir));
+                        }
                     }
                 }
 


### PR DESCRIPTION
Resolves #433

## Proposed Changes
- `Interface` folder root is included in the zip backup when `AddOns` is selected.
  Some users store proprietary data alongside the `AddOns` folder that they'd like
  included during backup.

## Checklist

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [x] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
