### PR TITLE
add alternating row colors 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Added
+
+- Row colors now alternate by default for better accessibility. This can be turned
+  off in settings under the UI section's "Alternate Row Colors" checkbox.
+
 ## [0.6.0] - 2020-12-20
 
 ### Added

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -216,6 +216,6 @@ pub async fn load_config() -> Result<Config, FilesystemError> {
     Ok(Config::load_or_default()?)
 }
 
-fn default_true() -> bool {
+const fn default_true() -> bool {
     true
 }

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -47,6 +47,9 @@ pub struct Config {
 
     #[serde(default)]
     pub weak_auras_account: HashMap<Flavor, String>,
+
+    #[serde(default = "default_true")]
+    pub alternating_row_colors: bool,
 }
 
 impl Config {
@@ -211,4 +214,8 @@ pub async fn load_config() -> Result<Config, FilesystemError> {
     log::debug!("loading config");
 
     Ok(Config::load_or_default()?)
+}
+
+fn default_true() -> bool {
+    true
 }

--- a/src/gui/element/catalog.rs
+++ b/src/gui/element/catalog.rs
@@ -101,6 +101,7 @@ pub fn data_row_container<'a, 'b>(
     column_config: &'b [(CatalogColumnKey, Length, bool)],
     installed_for_flavor: bool,
     install_addon: Option<&InstallAddon>,
+    is_odd: Option<bool>,
 ) -> TableRow<'a, Message> {
     let default_height = Length::Units(26);
     let default_row_height = 26;
@@ -360,11 +361,18 @@ pub fn data_row_container<'a, 'b>(
 
     row = row.push(right_spacer);
 
-    return TableRow::new(row)
+    let mut table_row = TableRow::new(row)
         .width(Length::Fill)
-        .style(style::TableRow(color_palette))
         .inner_row_height(default_row_height)
         .on_press(move |_| {
             Message::Interaction(Interaction::OpenLink(addon_data.website_url.clone()))
         });
+
+    if is_odd == Some(true) {
+        table_row = table_row.style(style::TableRowAlternate(color_palette))
+    } else {
+        table_row = table_row.style(style::TableRow(color_palette))
+    }
+
+    table_row
 }

--- a/src/gui/element/my_addons.rs
+++ b/src/gui/element/my_addons.rs
@@ -103,6 +103,7 @@ pub fn data_row_container<'a, 'b>(
     expand_type: &'a ExpandType,
     config: &Config,
     column_config: &'b [(ColumnKey, Length, bool)],
+    is_odd: Option<bool>,
 ) -> TableRow<'a, Message> {
     let default_height = Length::Units(26);
     let default_row_height = 26;
@@ -634,15 +635,22 @@ pub fn data_row_container<'a, 'b>(
         }
     }
 
-    return TableRow::new(addon_column)
+    let mut table_row = TableRow::new(addon_column)
         .width(Length::Fill)
         .inner_row_height(default_row_height)
-        .style(style::TableRow(color_palette))
         .on_press(move |_| {
             Message::Interaction(Interaction::Expand(ExpandType::Details(
                 addon_cloned_for_row.clone(),
             )))
         });
+
+    if is_odd == Some(true) {
+        table_row = table_row.style(style::TableRowAlternate(color_palette))
+    } else {
+        table_row = table_row.style(style::TableRow(color_palette))
+    }
+
+    table_row
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/gui/element/my_weakauras.rs
+++ b/src/gui/element/my_weakauras.rs
@@ -126,6 +126,7 @@ pub fn data_row_container<'a, 'b>(
     color_palette: ColorPalette,
     aura: &'a Aura,
     column_config: &'b [(AuraColumnKey, Length, bool)],
+    is_odd: Option<bool>,
 ) -> TableRow<'a, Message> {
     let default_height = Length::Units(26);
     let default_row_height = 26;
@@ -286,12 +287,17 @@ pub fn data_row_container<'a, 'b>(
 
     let mut table_row = TableRow::new(row)
         .width(Length::Fill)
-        .inner_row_height(default_row_height)
-        .style(style::TableRow(color_palette));
+        .inner_row_height(default_row_height);
 
     if let Some(url) = aura.url() {
         table_row = table_row
             .on_press(move |_| Message::Interaction(Interaction::OpenLink(url.to_string())));
+    }
+
+    if is_odd == Some(true) {
+        table_row = table_row.style(style::TableRowAlternate(color_palette))
+    } else {
+        table_row = table_row.style(style::TableRow(color_palette))
     }
 
     table_row

--- a/src/gui/element/settings.rs
+++ b/src/gui/element/settings.rs
@@ -97,12 +97,15 @@ pub fn data_container<'a, 'b>(
             Some(theme_state.current_theme_name.clone()),
             Message::ThemeSelected,
         )
-        .text_size(14)
+        .text_size(DEFAULT_FONT_SIZE)
         .width(Length::Units(120))
         .style(style::PickList(color_palette));
 
         // Data row for theme picker list.
-        let theme_data_row = Row::new().push(theme_pick_list);
+        let theme_data_row = Row::new()
+            .push(theme_pick_list)
+            .align_items(Align::Center)
+            .height(Length::Units(26));
 
         Column::new()
             .push(title_container)
@@ -136,7 +139,7 @@ pub fn data_container<'a, 'b>(
             .size(DEFAULT_FONT_SIZE)
             .vertical_alignment(VerticalAlignment::Center);
         let current_scale_container = Container::new(current_scale_text)
-            .height(Length::Units(25))
+            .height(Length::Fill)
             .center_y()
             .style(style::BrightBackgroundContainer(color_palette));
 
@@ -144,7 +147,9 @@ pub fn data_container<'a, 'b>(
         let scale_buttons_row = Row::new()
             .push(scale_down_button.map(Message::Interaction))
             .push(current_scale_container)
-            .push(scale_up_button.map(Message::Interaction));
+            .push(scale_up_button.map(Message::Interaction))
+            .align_items(Align::Center)
+            .height(Length::Units(26));
 
         Column::new()
             .push(scale_title_row)
@@ -372,6 +377,32 @@ pub fn data_container<'a, 'b>(
         Column::new().push(open_config_row)
     };
 
+    let alternate_row_color_column = {
+        let title_container =
+            Container::new(Text::new("Alternate Row Colors").size(DEFAULT_FONT_SIZE))
+                .style(style::NormalBackgroundContainer(color_palette));
+
+        let checkbox = Checkbox::new(
+            config.alternating_row_colors,
+            "",
+            Interaction::AlternatingRowColorToggled,
+        )
+        .style(style::DefaultCheckbox(color_palette))
+        .text_size(DEFAULT_FONT_SIZE);
+
+        let checkbox: Element<Interaction> = checkbox.into();
+
+        let data_row = Row::new()
+            .push(checkbox.map(Message::Interaction))
+            .align_items(Align::Center)
+            .height(Length::Units(26));
+
+        Column::new()
+            .push(title_container)
+            .push(Space::new(Length::Units(0), Length::Units(5)))
+            .push(data_row)
+    };
+
     let ui_title = Text::new("UI").size(DEFAULT_FONT_SIZE);
     let ui_title_container =
         Container::new(ui_title).style(style::BrightBackgroundContainer(color_palette));
@@ -387,6 +418,7 @@ pub fn data_container<'a, 'b>(
     let ui_row = Row::new()
         .push(theme_column)
         .push(scale_column)
+        .push(alternate_row_color_column)
         .spacing(DEFAULT_PADDING);
 
     let self_update_channel_container = {

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -116,6 +116,7 @@ pub enum Interaction {
     ToggleBackupFolder(bool, BackupFolderKind),
     PickSelfUpdateChannel(SelfUpdateChannel),
     PickGlobalReleaseChannel(GlobalReleaseChannel),
+    AlternatingRowColorToggled(bool),
 }
 
 #[derive(Debug)]
@@ -434,7 +435,7 @@ impl Application for Ajour {
                     .style(style::Scrollable(color_palette));
 
                 // Loops though the addons.
-                for addon in addons {
+                for (idx, addon) in addons.iter_mut().enumerate() {
                     // If hiding ignored addons, we will skip it.
                     if addon.state == AddonState::Ignored && self.config.hide_ignored_addons {
                         continue;
@@ -446,6 +447,12 @@ impl Application for Ajour {
                         ExpandType::None => false,
                     };
 
+                    let is_odd = if self.config.alternating_row_colors {
+                        Some(idx % 2 != 0)
+                    } else {
+                        None
+                    };
+
                     // A container cell which has all data about the current addon.
                     // If the addon is expanded, then this is also included in this container.
                     let addon_data_cell = element::my_addons::data_row_container(
@@ -455,6 +462,7 @@ impl Application for Ajour {
                         &self.expanded_type,
                         &self.config,
                         &column_config,
+                        is_odd,
                     );
 
                     // Adds the addon data cell to the scrollable.
@@ -528,11 +536,18 @@ impl Application for Ajour {
                     .height(Length::FillPortion(1))
                     .style(style::Scrollable(color_palette));
 
-                for aura in weak_auras_state.auras.iter() {
+                for (idx, aura) in weak_auras_state.auras.iter().enumerate() {
+                    let is_odd = if self.config.alternating_row_colors {
+                        Some(idx % 2 != 0)
+                    } else {
+                        None
+                    };
+
                     let row = element::my_weakauras::data_row_container(
                         color_palette,
                         aura,
                         &aura_column_config,
+                        is_odd,
                     );
 
                     scrollable = scrollable.push(row);
@@ -800,7 +815,18 @@ impl Application for Ajour {
 
                     let install_addons = self.install_addons.entry(flavor).or_default();
 
-                    for addon in self.catalog_search_state.catalog_rows.iter_mut() {
+                    for (idx, addon) in self
+                        .catalog_search_state
+                        .catalog_rows
+                        .iter_mut()
+                        .enumerate()
+                    {
+                        let is_odd = if self.config.alternating_row_colors {
+                            Some(idx % 2 != 0)
+                        } else {
+                            None
+                        };
+
                         // TODO (tarkah): We should make this prettier with new sources coming in.
                         let installed_for_flavor = addons.iter().any(|a| {
                             a.curse_id() == Some(addon.addon.id)
@@ -820,6 +846,7 @@ impl Application for Ajour {
                             &catalog_column_config,
                             installed_for_flavor,
                             install_addon,
+                            is_odd,
                         );
 
                         catalog_scrollable = catalog_scrollable.push(catalog_data_cell);

--- a/src/gui/style.rs
+++ b/src/gui/style.rs
@@ -476,6 +476,31 @@ impl table_row::StyleSheet for TableRow {
     }
 }
 
+pub struct TableRowAlternate(pub ColorPalette);
+impl table_row::StyleSheet for TableRowAlternate {
+    fn style(&self) -> table_row::Style {
+        let default = TableRow(self.0).style();
+
+        table_row::Style {
+            background: Some(Background::Color(Color {
+                a: 0.50,
+                ..self.0.base.foreground
+            })),
+            ..default
+        }
+    }
+    fn hovered(&self) -> table_row::Style {
+        let style = self.style();
+        table_row::Style {
+            background: Some(Background::Color(Color {
+                a: 0.15,
+                ..self.0.normal.primary
+            })),
+            ..style
+        }
+    }
+}
+
 pub struct ForegroundScrollable(pub ColorPalette);
 impl scrollable::StyleSheet for ForegroundScrollable {
     fn active(&self) -> scrollable::Scrollbar {

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -1806,6 +1806,15 @@ pub fn handle_message(ajour: &mut Ajour, message: Message) -> Result<Command<Mes
                 ajour.error = Some(error);
             }
         },
+        Message::Interaction(Interaction::AlternatingRowColorToggled(is_set)) => {
+            log::debug!(
+                "Interaction::AlternatingRowColorToggled(is_set: {})",
+                is_set,
+            );
+
+            ajour.config.alternating_row_colors = is_set;
+            let _ = ajour.config.save();
+        }
         Message::Error(error) => {
             log_error(&error);
             ajour.error = Some(error);


### PR DESCRIPTION

## Proposed Changes
  - Row colors now alternate by default for better accessibility. This can be turned
  off in settings under the UI section's "Alternate Row Colors" checkbox.

## Checklist

- [x] Tested on Windows
- [x] Tested on MacOS
- [x] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
