### PR TITLE
Change/remote version changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Added
+
+- Remote version can be clicked to directly open the changelog webpage.
+
 ### Fixed
 
 - Added "Beta / Alpha" release channel support for GitHub addons. Releases marked

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -347,6 +347,18 @@ impl Addon {
                     url
                 }
             }
+            Some(RepositoryKind::Curse) => {
+                let file = self
+                    .relevant_release_package(default_release_channel)
+                    .map(|r| r.file_id)
+                    .flatten();
+
+                if let Some(file) = file {
+                    url.map(|url| format!("{}/{}", url, file))
+                } else {
+                    url
+                }
+            }
             Some(_) => url,
             None => None,
         }

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -139,6 +139,8 @@ pub struct Addon {
     pub pick_release_channel_state: iced_native::pick_list::State<ReleaseChannel>,
     #[cfg(feature = "gui")]
     pub changelog_btn_state: iced_native::button::State,
+    #[cfg(feature = "gui")]
+    pub remote_version_btn_state: iced_native::button::State,
 }
 
 impl Addon {
@@ -168,6 +170,8 @@ impl Addon {
             pick_release_channel_state: Default::default(),
             #[cfg(feature = "gui")]
             changelog_btn_state: Default::default(),
+            #[cfg(feature = "gui")]
+            remote_version_btn_state: Default::default(),
         }
     }
 

--- a/src/gui/element/my_addons.rs
+++ b/src/gui/element/my_addons.rs
@@ -126,12 +126,6 @@ pub fn data_row_container<'a, 'b>(
         .map(str::to_string)
         .unwrap_or_else(|| "-".to_string());
     let release_package = addon_cloned.relevant_release_package(global_release_channel);
-    let remote_version = if let Some(package) = &release_package {
-        package.version.clone()
-    } else {
-        String::from("-")
-    };
-    let remote_version = Text::new(remote_version).size(DEFAULT_FONT_SIZE);
 
     if let Some((idx, width)) = column_config
         .iter()
@@ -210,12 +204,31 @@ pub fn data_row_container<'a, 'b>(
         })
         .next()
     {
-        let remote_version_container = Container::new(remote_version)
-            .padding(5)
-            .height(default_height)
-            .width(*width)
-            .center_y()
-            .style(style::HoverableForegroundContainer(color_palette));
+        let remote_version = if let Some(package) = &release_package {
+            package.version.clone()
+        } else {
+            String::from("-")
+        };
+        let remote_version = Text::new(remote_version).size(DEFAULT_FONT_SIZE);
+
+        let mut remote_version_button =
+            Button::new(&mut addon.remote_version_btn_state, remote_version)
+                .style(style::BrightTextButton(color_palette));
+
+        if let Some(link) = &changelog_url {
+            remote_version_button =
+                remote_version_button.on_press(Interaction::OpenLink(link.clone()));
+        }
+
+        let remote_version_button: Element<Interaction> = remote_version_button.into();
+
+        let remote_version_container =
+            Container::new(remote_version_button.map(Message::Interaction))
+                //.padding(5)
+                .height(default_height)
+                .width(*width)
+                .center_y()
+                .style(style::HoverableForegroundContainer(color_palette));
 
         row_containers.push((idx, remote_version_container));
     }

--- a/src/gui/element/my_addons.rs
+++ b/src/gui/element/my_addons.rs
@@ -224,7 +224,6 @@ pub fn data_row_container<'a, 'b>(
 
         let remote_version_container =
             Container::new(remote_version_button.map(Message::Interaction))
-                //.padding(5)
                 .height(default_height)
                 .width(*width)
                 .center_y()


### PR DESCRIPTION
## Proposed Changes
  - Make remote version in row clickable to open changelog website
  - Curse link has also been updated to open to the specific file instead of all files window

## Checklist

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [x] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
