### PR TITLE
set custom config dir before setting up logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ and `Removed`.
   name instead of parsed repo from the user inputted URL
 - Removed minimum window size on Linux. This fixed a issue where the application
   would not be resizable.
-- Fixed bug where log file didn't respect custom `--data` path. Log is now created under the supplied `--data` path.
+- Fixed bug where log file didn't respect custom `--data` path. Log is now created
+  under the supplied `--data` path.
 
 ## [0.6.0] - 2020-12-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and `Removed`.
   name instead of parsed repo from the user inputted URL
 - Removed minimum window size on Linux. This fixed a issue where the application
   would not be resizable.
+- Fixed bug where log file didn't respect custom `--data` path. Log is now created under the supplied `--data` path.
 
 ## [0.6.0] - 2020-12-20
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,12 @@ pub fn main() {
     // fix that allows us to print to the console when not using the GUI.
     let opts = cli::validate_opts_or_exit(opts_result, is_cli, is_debug);
 
+    if let Some(data_dir) = &opts.data_directory {
+        let mut config_dir = CONFIG_DIR.lock().unwrap();
+
+        *config_dir = data_dir.clone();
+    }
+
     setup_logger(is_cli, is_debug).expect("setup logging");
 
     // Called when we launch from the temp (new release) binary during the self update
@@ -52,12 +58,6 @@ pub fn main() {
             log_error(&e);
             std::process::exit(1);
         }
-    }
-
-    if let Some(data_dir) = &opts.data_directory {
-        let mut config_dir = CONFIG_DIR.lock().unwrap();
-
-        *config_dir = data_dir.clone();
     }
 
     log_panics::init();


### PR DESCRIPTION
Resolves #457

## Proposed Changes
  - Set custom config dir before setting up logging, not after :P

## Checklist

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [x] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
