### PR TITLE
chore: removed force install from addons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and `Removed`.
 - `Interface` folder root is included in the zip backup when `AddOns` is selected.
   Some users store proprietary data alongside the `AddOns` folder that they'd like
   included during backup.
+- Removed `Force install` as it had no value.
 
 ### Fixed
 

--- a/crates/core/src/addon.rs
+++ b/crates/core/src/addon.rs
@@ -126,8 +126,6 @@ pub struct Addon {
     #[cfg(feature = "gui")]
     pub update_btn_state: iced_native::button::State,
     #[cfg(feature = "gui")]
-    pub force_btn_state: iced_native::button::State,
-    #[cfg(feature = "gui")]
     pub delete_btn_state: iced_native::button::State,
     #[cfg(feature = "gui")]
     pub ignore_btn_state: iced_native::button::State,
@@ -156,8 +154,6 @@ impl Addon {
             details_btn_state: Default::default(),
             #[cfg(feature = "gui")]
             update_btn_state: Default::default(),
-            #[cfg(feature = "gui")]
-            force_btn_state: Default::default(),
             #[cfg(feature = "gui")]
             delete_btn_state: Default::default(),
             #[cfg(feature = "gui")]

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -1180,7 +1180,7 @@ pub fn parse_toc_path(toc_path: &PathBuf) -> Option<AddonFolder> {
 
 /// Helper function to split a comma separated string into `Vec<String>`.
 fn split_dependencies_into_vec(value: &str) -> Vec<String> {
-    if value == "" {
+    if value.is_empty() {
         return vec![];
     }
 

--- a/src/gui/element/my_addons.rs
+++ b/src/gui/element/my_addons.rs
@@ -541,20 +541,6 @@ pub fn data_row_container<'a, 'b>(
 
             let website_button: Element<Interaction> = website_button.into();
 
-            let mut force_download_button = Button::new(
-                &mut addon.force_btn_state,
-                Text::new("Force update").size(DEFAULT_FONT_SIZE),
-            )
-            .style(style::DefaultButton(color_palette));
-
-            // If we have a release package on addon, enable force update.
-            if release_package.is_some() {
-                force_download_button = force_download_button
-                    .on_press(Interaction::Update(addon.primary_folder_id.clone()));
-            }
-
-            let force_download_button: Element<Interaction> = force_download_button.into();
-
             let is_ignored = addon.state == AddonState::Ignored;
             let ignore_button_text = if is_ignored {
                 Text::new("Unignore").size(DEFAULT_FONT_SIZE)
@@ -605,8 +591,6 @@ pub fn data_row_container<'a, 'b>(
                 .push(website_button.map(Message::Interaction))
                 .push(Space::new(Length::Units(5), Length::Units(0)))
                 .push(changelog_button.map(Message::Interaction))
-                .push(Space::new(Length::Units(5), Length::Units(0)))
-                .push(force_download_button.map(Message::Interaction))
                 .push(Space::new(Length::Units(5), Length::Units(0)))
                 .push(ignore_button.map(Message::Interaction))
                 .push(Space::new(Length::Units(5), Length::Units(0)))


### PR DESCRIPTION
Resolves better UX.

## Proposed Changes
  - `Force install` had little to no value.

## Checklist

- [ ] Tested on Windows
- [X] Tested on MacOS
- [ ] Tested on Linux
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
