### PR TITLE
fix: catalog pixel difference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and `Removed`.
   would not be resizable.
 - Fixed bug where log file didn't respect custom `--data` path. Log is now created
   under the supplied `--data` path.
+- Small height difference in Catalog search menu.
 
 ## [0.6.0] - 2020-12-20
 

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -1180,7 +1180,7 @@ pub fn parse_toc_path(toc_path: &PathBuf) -> Option<AddonFolder> {
 
 /// Helper function to split a comma separated string into `Vec<String>`.
 fn split_dependencies_into_vec(value: &str) -> Vec<String> {
-    if value == "" {
+    if value.is_empty() {
         return vec![];
     }
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -799,7 +799,7 @@ impl Application for Ajour {
 
                     let catalog_query_container = Container::new(catalog_query_row)
                         .width(Length::Fill)
-                        .height(Length::Units(35))
+                        .height(Length::Units(34))
                         .center_y();
 
                     let catalog_row_titles = element::catalog::titles_row_header(


### PR DESCRIPTION
Resolves a little pixel height difference in catalog. See blow.

<img width="436" alt="Screenshot 2021-01-01 at 15 10 31" src="https://user-images.githubusercontent.com/2248455/103440190-db423080-4c43-11eb-9979-9e0749e8612f.png">

## Checklist

- [ ] Tested on Windows
- [X] Tested on MacOS
- [ ] Tested on Linux
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
