### PR TITLE
weak auras fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and `Removed`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Parsing error causing WeakAuras to fail parsing due to missing "version" field
+- Incorrect percent encoding in WeakAuras API calls causing auras to not display
+
 ## [0.6.1] - 2021-01-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
  "futures",
  "isahc",
  "mlua",
+ "percent-encoding",
  "serde",
  "serde_json",
  "structopt",

--- a/crates/weak_auras/Cargo.toml
+++ b/crates/weak_auras/Cargo.toml
@@ -23,6 +23,7 @@ async-std = { version = "1.6", features = ["unstable"] }
 futures = "0.3"
 isahc = { version = "0.9.6", features = ["json"] }
 mlua = { version = "0.4", features = ["lua53", "vendored"] }
+percent-encoding = "2.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1.0"

--- a/crates/weak_auras/src/lib.rs
+++ b/crates/weak_auras/src/lib.rs
@@ -311,7 +311,7 @@ impl Aura {
     }
 
     pub fn installed_version(&self) -> Option<u16> {
-        self.parent_display().map(|d| d.version)
+        self.parent_display().and_then(|d| d.version)
     }
 
     pub fn remote_version(&self) -> u16 {
@@ -378,7 +378,7 @@ struct AuraChangelog {
 struct AuraDisplay {
     url: String,
     slug: String,
-    version: u16,
+    version: Option<u16>,
     version_string: Option<String>,
     parent: Option<String>,
     id: String,
@@ -405,12 +405,15 @@ impl<'lua> FromLua<'lua> for MaybeAuraDisplay {
                     path.next();
 
                     let slug = path.next();
+                    let version = path.next().map(str::parse::<u16>).and_then(Result::ok);
 
                     if let Some(slug) = slug {
                         let parent = table.get("parent")?;
                         let id = table.get("id")?;
                         let uid = table.get("uid")?;
-                        let version = table.get("version")?;
+                        let version = table
+                            .get::<_, Option<u16>>("version")?
+                            .map_or(version, Option::Some);
                         let version_string = table.get("semver")?;
                         let ignore_updates = table
                             .get::<_, Option<bool>>("ignoreWagoUpdate")?


### PR DESCRIPTION
Resolves #465, #466

## Proposed Changes
  - Make aura display field Version an Option since it's not always present. If not present, we will try to use the version from the URL field.
  - Fix the API calls to percent encode the parameters. Some slugs have `&` symbol in it, causing error in built URL

## Checklist

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
