### PR TITLE
feat: relative time localization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,7 @@ dependencies = [
  "iced_native",
  "image",
  "isahc",
+ "isolang",
  "json-gettext",
  "log",
  "log-panics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ chrono = { version = "0.4", features = ['serde'] }
 log = "0.4"
 fern = "0.6"
 timeago = "0.2.1"
+isolang = "1.0.0"
 log-panics = { version = "2.0", features=['with-backtrace'] }
 structopt = "0.3"
 num-format = "0.4.0"

--- a/src/gui/element/catalog.rs
+++ b/src/gui/element/catalog.rs
@@ -4,7 +4,7 @@ use {
         style, Catalog, CatalogColumnKey, CatalogColumnState, CatalogRow, InstallAddon,
         InstallKind, InstallStatus, Interaction, Message, Mode, SortDirection,
     },
-    crate::localization::localized_string,
+    crate::localization::{localized_string, localized_timeago_formatter},
     ajour_core::{config::Config, theme::ColorPalette},
     ajour_widgets::{header, Header, TableRow},
     chrono::prelude::*,
@@ -302,10 +302,8 @@ pub fn data_row_container<'a, 'b>(
         })
         .next()
     {
-        // TODO (casperstorm): localization timeago.
-        // @see: https://docs.rs/timeago/0.2.1/timeago/
         let release_date_text: String = if let Some(date_released) = addon_data.date_released {
-            let f = timeago::Formatter::new();
+            let f = localized_timeago_formatter();
             let now = Local::now();
             f.convert_chrono(date_released, now)
         } else {

--- a/src/gui/element/my_addons.rs
+++ b/src/gui/element/my_addons.rs
@@ -4,7 +4,7 @@ use {
         style, ColumnKey, ColumnState, ExpandType, Flavor, Interaction, Message, Mode,
         ReleaseChannel, SortDirection, State,
     },
-    crate::localization::localized_string,
+    crate::localization::{localized_string, localized_timeago_formatter},
     ajour_core::{
         addon::{Addon, AddonState},
         config::Config,
@@ -321,10 +321,8 @@ pub fn data_row_container<'a, 'b>(
         })
         .next()
     {
-        // TODO (casperstorm): localization timeago.
-        // @see: https://docs.rs/timeago/0.2.1/timeago/
         let release_date_text: String = if let Some(package) = &release_package {
-            let f = timeago::Formatter::new();
+            let f = localized_timeago_formatter();
             let now = Local::now();
 
             if let Some(time) = package.date_time.as_ref() {
@@ -516,7 +514,7 @@ pub fn data_row_container<'a, 'b>(
                     .style(style::HoverableBrightForegroundContainer(color_palette));
 
                 let release_date_text: String = if let Some(package) = &release_package {
-                    let f = timeago::Formatter::new();
+                    let f = localized_timeago_formatter();
                     let now = Local::now();
 
                     if let Some(time) = package.date_time.as_ref() {

--- a/src/localization.rs
+++ b/src/localization.rs
@@ -28,6 +28,21 @@ pub fn localized_string(key: &str) -> String {
         .to_string()
 }
 
+/// Returns a localized `timeago::Formatter`.
+/// If user has chosen a language whic his not supported by `timeago` we fallback to english.
+pub fn localized_timeago_formatter() -> timeago::Formatter<Box<dyn timeago::Language>> {
+    let lang = LANG.get().expect("LANG not set").read().unwrap();
+    let isolang = isolang::Language::from_locale(&lang).unwrap();
+
+    // this step might fail if timeago does not support the chosen language.
+    // In that case we fallback to `en_US`.
+    if let Some(timeago_lang) = timeago::from_isolang(isolang) {
+        timeago::Formatter::with_language(timeago_lang)
+    } else {
+        timeago::Formatter::with_language(Box::new(timeago::English))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use serde::Deserialize;


### PR DESCRIPTION
`timeago` crate had support for localization, i've implemented it with fallback to english.

## Checklist

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
