### PR TITLE
fuzzy match tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and `Removed`.
 ### Changed
 
 - Refreshed the menu with a more simple and uncluttered look.
+- Catalog fuzzy matching better removes unrelated results while retaining relevant
+  results
 
 ## [0.6.3] - 2021-01-14
 

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -2366,6 +2366,8 @@ fn query_and_sort_catalog(ajour: &mut Ajour) {
 
         // Use default, can tweak if needed in future
         let fuzzy_match_config = SkimScoreConfig {
+            gap_start: -12,
+            gap_extension: -6,
             ..Default::default()
         };
         let fuzzy_matcher = SkimMatcherV2::default().score_config(fuzzy_match_config);
@@ -2384,9 +2386,11 @@ fn query_and_sort_catalog(ajour: &mut Ajour) {
                         None
                     }
                 } else {
-                    Some((a, 0))
+                    Some((a, 1))
                 }
             })
+            // Only return positive scores
+            .filter(|(_, s)| *s > 0)
             .filter(|(a, _)| {
                 a.game_versions
                     .iter()

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -2364,7 +2364,7 @@ fn query_and_sort_catalog(ajour: &mut Ajour) {
         let category = &ajour.catalog_search_state.category;
         let result_size = ajour.catalog_search_state.result_size.as_usize();
 
-        // Use default, can tweak if needed in future
+        // Increase penalty for gaps between matching characters
         let fuzzy_match_config = SkimScoreConfig {
             gap_start: -12,
             gap_extension: -6,


### PR DESCRIPTION
Resolves #462

## Proposed Changes
  - Filter out scores that are negative. When I first implemented this, I thought it would only return positive scores by default but never checked. This helps remove a ton of non-related results.
  - Increase the penalty for when gaps occur in matches characters vs the search pattern. This helps push even more results negative and cleans up the results. We prefer matches that closely match the search pattern or at least have consecutive characters and not too many spaces between matching characters.

## Checklist

- [x] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
